### PR TITLE
Format INR inputs and outputs

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -153,14 +153,14 @@
         <h2>HT Bill — Inputs <span class="help">Manual entries from utility bill</span></h2>
         <div class="fields">
           <div class="f"><label>Monthly Consumption (kWh) <span class="mono">A4</span></label><input type="number" id="A4" step="0.001"/></div>
-          <div class="f"><label>Demand Charges (₹) <span class="mono">B4</span></label><input type="number" id="B4" step="0.01"/></div>
-          <div class="f"><label>Energy Charges (₹) <span class="mono">C4</span></label><input type="number" id="C4" step="0.01"/></div>
-          <div class="f"><label>Night Rebate (₹) <span class="mono">D4</span></label><input type="number" id="D4" step="0.01"/></div>
-          <div class="f"><label>Fuel Charge (₹) <span class="mono">E4</span></label><input type="number" id="E4" step="0.01"/></div>
-          <div class="f"><label>PF Rebate (₹) <span class="mono">F4</span></label><input type="number" id="F4" step="0.01"/></div>
-          <div class="f"><label>EHV Rebate (₹) <span class="mono">G4</span></label><input type="number" id="G4" step="0.01"/></div>
-          <div class="f"><label>TOU (₹) <span class="mono">H4</span></label><input type="number" id="H4" step="0.01"/></div>
-          <div class="f"><label>GT Charges (₹) <span class="mono">I4</span></label><input type="number" id="I4" step="0.01"/></div>
+          <div class="f"><label>Demand Charges (₹) <span class="mono">B4</span></label><input type="text" id="B4"/></div>
+          <div class="f"><label>Energy Charges (₹) <span class="mono">C4</span></label><input type="text" id="C4"/></div>
+          <div class="f"><label>Night Rebate (₹) <span class="mono">D4</span></label><input type="text" id="D4"/></div>
+          <div class="f"><label>Fuel Charge (₹) <span class="mono">E4</span></label><input type="text" id="E4"/></div>
+          <div class="f"><label>PF Rebate (₹) <span class="mono">F4</span></label><input type="text" id="F4"/></div>
+          <div class="f"><label>EHV Rebate (₹) <span class="mono">G4</span></label><input type="text" id="G4"/></div>
+          <div class="f"><label>TOU (₹) <span class="mono">H4</span></label><input type="text" id="H4"/></div>
+          <div class="f"><label>GT Charges (₹) <span class="mono">I4</span></label><input type="text" id="I4"/></div>
         </div>
         <div class="hr"></div>
         <div class="kpi">
@@ -174,10 +174,10 @@
       <section class="card span-6">
         <h2>Adjustments & Carry‑forward <span class="help">Manual entries</span></h2>
         <div class="fields">
-          <div class="f sm"><label>Outstanding Arrears (₹) <span class="mono">D9</span></label><input type="number" id="D9" step="0.01"/></div>
-          <div class="f sm"><label>Freeze Amount (₹) <span class="mono">E9</span></label><input type="number" id="E9" step="0.01"/></div>
-          <div class="f sm"><label>Delayed Payment Charges (₹) <span class="mono">F9</span></label><input type="number" id="F9" step="0.01"/></div>
-          <div class="f sm"><label>Advance Payment / Adjust. (₹) <span class="mono">G9</span></label><input type="number" id="G9" step="0.01"/></div>
+          <div class="f sm"><label>Outstanding Arrears (₹) <span class="mono">D9</span></label><input type="text" id="D9"/></div>
+          <div class="f sm"><label>Freeze Amount (₹) <span class="mono">E9</span></label><input type="text" id="E9"/></div>
+          <div class="f sm"><label>Delayed Payment Charges (₹) <span class="mono">F9</span></label><input type="text" id="F9"/></div>
+          <div class="f sm"><label>Advance Payment / Adjust. (₹) <span class="mono">G9</span></label><input type="text" id="G9"/></div>
         </div>
         <div class="hr"></div>
         <div class="kpi">
@@ -217,12 +217,12 @@
       <section class="card span-6">
         <h2>Wind Credits & Debits <span class="help">Prior‐month adjustments</span></h2>
         <div class="fields">
-          <div class="f sm"><label>Credit Board Charges (₹) <span class="mono">A24</span></label><input type="number" id="A24" step="0.01"/></div>
-          <div class="f sm"><label>Credit ED Charges (₹) <span class="mono">B24</span></label><input type="number" id="B24" step="0.01"/></div>
-          <div class="f sm"><label>Credit TDS (₹) <span class="mono">C24</span></label><input type="number" id="C24" step="0.01"/></div>
-          <div class="f sm"><label>Debit Board Charges (₹) <span class="mono">D24</span></label><input type="number" id="D24" step="0.01"/></div>
-          <div class="f sm"><label>Debit Electricity Duty (₹) <span class="mono">E24</span></label><input type="number" id="E24" step="0.01"/></div>
-          <div class="f sm"><label>Debit Wheeling Charges (₹) <span class="mono">F24</span></label><input type="number" id="F24" step="0.01"/></div>
+          <div class="f sm"><label>Credit Board Charges (₹) <span class="mono">A24</span></label><input type="text" id="A24"/></div>
+          <div class="f sm"><label>Credit ED Charges (₹) <span class="mono">B24</span></label><input type="text" id="B24"/></div>
+          <div class="f sm"><label>Credit TDS (₹) <span class="mono">C24</span></label><input type="text" id="C24"/></div>
+          <div class="f sm"><label>Debit Board Charges (₹) <span class="mono">D24</span></label><input type="text" id="D24"/></div>
+          <div class="f sm"><label>Debit Electricity Duty (₹) <span class="mono">E24</span></label><input type="text" id="E24"/></div>
+          <div class="f sm"><label>Debit Wheeling Charges (₹) <span class="mono">F24</span></label><input type="text" id="F24"/></div>
         </div>
         <div class="hr"></div>
         <div class="kpi">
@@ -277,10 +277,24 @@
 
     const $ = id => document.getElementById(id);
     const num = id => {
-      const v = parseFloat($(id).value);
-      return Number.isFinite(v) ? v : 0;
+      const el = $(id);
+      return parseFloat(el.dataset.value || el.value || 0) || 0;
     };
     const roundUp0 = x => Math.ceil(x);
+
+    const toInr = v => INR.format(Number.isFinite(v) ? v : 0);
+    const toRate = v => RATE.format(Number.isFinite(v) ? v : 0) + ' /kWh';
+    function parseInrInput(el){
+      const raw = el.value.replace(/[^0-9.\-]/g,'');
+      const v = parseFloat(raw);
+      if(Number.isFinite(v)){
+        el.dataset.value = v;
+        el.value = toInr(v);
+      }else{
+        el.dataset.value = '';
+        el.value = '';
+      }
+    }
 
     function compute(){
       // HT Bill
@@ -288,18 +302,18 @@
       const A9 = B4 + C4 + D4 + E4 - F4 - G4 + H4 + I4;
       const B9 = A9 * 0.2;
       const C9 = A9 + B9;
-      $('A9v').textContent = INR.format(A9);
-      $('B9v').textContent = INR.format(B9);
-      $('C9v').textContent = INR.format(C9);
+      $('A9v').textContent = toInr(A9);
+      $('B9v').textContent = toInr(B9);
+      $('C9v').textContent = toInr(C9);
 
       // Adjustments
       const D9=num('D9'), E9=num('E9'), F9=num('F9'), G9=num('G9');
       const H9 = C9 + D9 + F9 - G9;
       const I9 = H9 - E9;
       const A31 = D9 - E9;
-      $('H9v').textContent = INR.format(H9);
-      $('I9v').textContent = INR.format(I9);
-      $('A31v').textContent = INR.format(A31);
+      $('H9v').textContent = toInr(H9);
+      $('I9v').textContent = toInr(I9);
+      $('A31v').textContent = toInr(A31);
 
       // WEG Inputs
       const B15=num('B15'), D15=num('D15'), C16=num('C16');
@@ -318,27 +332,31 @@
       const A26 = A24 + B24;
       const B26 = D24 + E24 + F24;
       const C26 = A26 - B26;
-      $('A26v').textContent = INR.format(A26);
-      $('B26v').textContent = INR.format(B26);
-      $('C26v').textContent = INR.format(C26);
+      $('A26v').textContent = toInr(A26);
+      $('B26v').textContent = toInr(B26);
+      $('C26v').textContent = toInr(C26);
 
       // Rates & Shares
       const B19 = (A19===0) ? 0 : (C26 / A19);
       const F16 = B19 * A18;
       const G16 = B19 * C18;
-      $('B19v').textContent = RATE.format(B19) + ' /kWh';
-      $('F16v').textContent = INR.format(F16);
-      $('G16v').textContent = INR.format(G16);
+      $('B19v').textContent = toRate(B19);
+      $('F16v').textContent = toInr(F16);
+      $('G16v').textContent = toInr(G16);
 
       // Final Bill for IOM
       const FINAL = C9 - F16 - G16 - C24 + A31 + F9; // C9 − F16 − G16 − Credit TDS + Balance Pending + Delay Charges
-      $('FINALv').textContent = INR.format(FINAL);
+      $('FINALv').textContent = toInr(FINAL);
 
       return { A4,B4,C4,D4,E4,F4,G4,H4,I4, A9,B9,C9, D9,E9,F9,G9,H9,I9, B15,D15,C16, A17,B17,C17,D17,E17, A18,C18,A19, A24,B24,C24,D24,E24,F24, A26,B26,C26, B19,F16,G16, A31, FINAL };
     }
 
     // Attach inputs
-    document.querySelectorAll('input').forEach(el=>{
+    document.querySelectorAll('input[type="text"]').forEach(el=>{
+      el.addEventListener('input', ()=>{ parseInrInput(el); compute(); });
+      el.addEventListener('blur', ()=>parseInrInput(el));
+    });
+    document.querySelectorAll('input:not([type="text"])').forEach(el=>{
       el.addEventListener('input', compute);
     });
 
@@ -474,13 +492,22 @@
     });
 
     $('resetAll').addEventListener('click', ()=>{
-      document.querySelectorAll('input').forEach(el=>{ if(el.type!=="month") el.value=''; });
+      document.querySelectorAll('input').forEach(el=>{
+        if(el.type!=="month"){
+          el.value='';
+          el.dataset.value='';
+        }
+      });
       compute();
     });
 
     $('resetSample').addEventListener('click', ()=>{
       const sample = {A4:1000,B4:5000,C4:8000,D4:200,E4:300,F4:100,G4:50,H4:400,I4:600,D9:200,E9:50,F9:30,G9:0,B15:30,D15:70,C16:2,A17:1,B17:1,C17:2,D17:1,E17:1,A24:500,B24:200,C24:100,D24:50,E24:25,F24:25};
-      Object.entries(sample).forEach(([id,val])=>$(id).value = val);
+      Object.entries(sample).forEach(([id,val])=>{
+        const el = $(id);
+        el.value = val;
+        if(el.type==='text') parseInrInput(el);
+      });
       compute();
     });
 


### PR DESCRIPTION
## Summary
- Allow currency fields to display formatted INR values by switching to text inputs and tracking raw numbers in `data-value`.
- Add `toInr`, `toRate`, and `parseInrInput` helpers and wire up input/blur handlers to format entries.
- Format computed KPIs using the new helpers for consistent INR and rate output.

## Testing
- ⚠️ `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689dba33a9588333875a7aecdcb17cc8