### PR TITLE
Improve focus indicators and text contrast for accessibility

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -9,18 +9,19 @@
       --bg:#0f172a;          /* slate-900 */
       --card:#111827;        /* gray-900 */
       --ink:#e5e7eb;         /* gray-200 */
-      --muted:#94a3b8;       /* slate-400 */
+      --muted:#cbd5e1;       /* slate-300 */
       --accent:#22d3ee;      /* cyan-400 */
       --accent-2:#a78bfa;    /* violet-400 */
       --good:#22c55e;        /* green-500 */
       --bad:#ef4444;         /* red-500 */
       --warn:#f59e0b;        /* amber-500 */
       --panel:#0b1224;       /* deep */
-      --ring: 0 0 0 2px rgba(34,211,238,.45);
+      --ring:2px solid rgba(34,211,238,.6);
       --shadow: 0 20px 50px rgba(0,0,0,.45);
       --radius: 18px;
     }
     *{box-sizing:border-box}
+    :focus-visible{outline:var(--ring);outline-offset:2px}
     html,body{height:100%}
     body{
       margin:0;
@@ -35,7 +36,7 @@
     .brand{display:flex;align-items:center;gap:12px}
     .brand svg{width:34px;height:34px}
     .brand h1{margin:0;font-size:22px;letter-spacing:.3px}
-    .sub{color:var(--muted);font-size:13.5px}
+    .sub{color:var(--ink);font-size:13.5px}
 
     .toolbar{display:flex;gap:10px;flex-wrap:wrap;position:sticky;top:0;background:var(--bg);z-index:10;padding:8px 0}
     button, .ghost{
@@ -63,7 +64,7 @@
     }
 
     .card h2{margin:0 0 12px 0;font-size:16px;font-weight:700;display:flex;justify-content:space-between;align-items:center}
-    .help{color:var(--muted);font-size:12px}
+    .help{color:var(--ink);font-size:12px}
 
     .fields{display:grid;grid-template-columns:repeat(12,1fr);gap:10px}
     .fields .f{grid-column:span 12}
@@ -71,12 +72,11 @@
     .fields .f.sm{grid-column:span 6}
     @media(min-width:860px){.fields .f.sm{grid-column:span 3}}
 
-    label{display:flex;justify-content:space-between;gap:8px;color:var(--muted);font-size:12.5px;margin-bottom:6px}
+    label{display:flex;justify-content:space-between;gap:8px;color:var(--ink);font-size:12.5px;margin-bottom:6px}
     input[type="number"], input[type="month"], input[type="text"]{
       width:100%;padding:10px 12px;border-radius:12px;border:1px solid rgba(255,255,255,.12);
-      outline:none;background:rgba(17,24,39,.6);color:var(--ink)
+      background:rgba(17,24,39,.6);color:var(--ink)
     }
-    input:focus{box-shadow:var(--ring)}
 
     .kpi{
       display:grid;grid-template-columns:repeat(12,1fr);gap:10px;margin-top:6px


### PR DESCRIPTION
## Summary
- lighten muted palette and strengthen help/label text colors for improved contrast
- add global `:focus-visible` outline using `--ring`
- ensure inputs use default outlines and remove custom box-shadow focus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dbe77bdf083338bfb67b01a915d20