### PR TITLE
feat: add dynamic pdf loader and download button

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -158,6 +158,7 @@
           <span>Auto‑update month on Download</span>
         </label>
         <button id="downloadExcel">Download Excel</button>
+        <button id="downloadPDF">Download IOM PDF</button>
           <button class="ghost" id="resetAll">Reset</button>
           <button class="ghost" id="clearSheets">Clear Sheets</button>
           <button id="resetSample">Sample Data</button><!-- fills fields with example screenshot values -->
@@ -332,6 +333,59 @@
       })();
       const ok = await __xlsxLoading;
       __xlsxLoading = null;
+      return ok;
+    }
+
+    // Single-flight, on-demand pdfMake loader
+    // Tries: ?pdf=override → ./pdfmake.min.js (local) → CDNs
+    let __pdfLoading = null;
+    async function loadPDF(){
+      if (window.pdfMake) return true;
+      if (__pdfLoading) return __pdfLoading;
+      __pdfLoading = (async () => {
+        const qp = new URLSearchParams(location.search);
+        const override = qp.get('pdf');
+        const urls = [
+          ...(override ? [override] : []),
+          './pdfmake.min.js',
+          'https://cdn.jsdelivr.net/npm/pdfmake@0.2.7/build/pdfmake.min.js',
+          'https://unpkg.com/pdfmake@0.2.7/build/pdfmake.min.js'
+        ];
+        let lastTried = '';
+        for(const src of urls){
+          lastTried = src;
+          try{
+            await new Promise((resolve, reject) => {
+              const s = document.createElement('script');
+              s.src = src;
+              s.async = true;
+              s.onload = resolve;
+              s.onerror = reject;
+              document.head.appendChild(s);
+            });
+            if(window.pdfMake) break;
+          }catch{/* try next */}
+        }
+        if(!window.pdfMake){
+          toast(`PDF library failed to load (last: ${lastTried}). You are likely offline or a CSP blocked CDNs. Place "pdfmake.min.js" next to this HTML or pass ?pdf=/path/to/pdfmake.min.js`, 'bad');
+          return false;
+        }
+        for(const src of ['./vfs_fonts.js','./vfs_noto_deva.js']){
+          try{
+            await new Promise((resolve, reject) => {
+              const s = document.createElement('script');
+              s.src = src;
+              s.async = true;
+              s.onload = resolve;
+              s.onerror = reject;
+              document.head.appendChild(s);
+            });
+          }catch{/* ignore */}
+        }
+        return true;
+      })();
+      const ok = await __pdfLoading;
+      __pdfLoading = null;
       return ok;
     }
 
@@ -840,6 +894,13 @@
         XLSX.writeFile(_wb, `WEG_Billing_${monthLabel()}.xlsx`);
         toast('Workbook downloaded.', 'good');
         } finally { __dlInFlight = false; }
+      }));
+
+      $('downloadPDF').addEventListener('click', () => withBusy('downloadPDF', async () => {
+        if (!(await loadPDF())) return;
+        const m = compute(true);
+        if (!m) { toast('Cannot download: fix inputs first.', 'warn'); return; }
+        generateIOMPDF(m, monthLabel());
       }));
 
       $('uploadExcel').addEventListener('click', () => withBusy('uploadExcel', async () => {


### PR DESCRIPTION
## Summary
- add loadPDF helper to dynamically load pdfmake with local and CDN fallbacks
- add "Download IOM PDF" toolbar button and hook
- attempt loading vfs fonts for pdf generation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eeb704dc08333aa35134cdd6eb2e3