### PR TITLE
Implement formatted IOM PDF generation

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -284,6 +284,7 @@
   <!-- SheetJS for Excel export -->
   <!-- Prefer a local copy for offline/file:// usage; keep dynamic loader as fallback -->
   <script src="./xlsx.full.min.js"></script>
+  <script src="./iom-pdf.js"></script>
   <script>
     function toast(msg, type='info'){
       const t = document.createElement('div');

--- a/iom-pdf.js
+++ b/iom-pdf.js
@@ -1,32 +1,127 @@
-import pdfMake from 'pdfmake/build/pdfmake';
-import 'pdfmake/build/vfs_fonts';
-import notoVfs from './vfs_noto_deva.js';
+(function(global){
+  // Number formatters
+  const INR = new Intl.NumberFormat('en-IN', {
+    style: 'currency',
+    currency: 'INR',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+  const KWH = new Intl.NumberFormat('en-IN', { maximumFractionDigits: 0 });
+  const MWH = new Intl.NumberFormat('en-IN', {
+    minimumFractionDigits: 3,
+    maximumFractionDigits: 3
+  });
+  const RATE = new Intl.NumberFormat('en-IN', {
+    style: 'currency',
+    currency: 'INR',
+    minimumFractionDigits: 6,
+    maximumFractionDigits: 6
+  });
 
-// Extend built-in Roboto vfs with Noto Devanagari fonts
-pdfMake.vfs = { ...pdfMake.vfs, ...notoVfs };
+  function fmtCurrency(v){ return INR.format(Number.isFinite(v) ? v : 0); }
+  function fmtKwh(v){ return KWH.format(Number.isFinite(v) ? v : 0); }
+  function fmtMwh(v){ return MWH.format(Number.isFinite(v) ? v : 0); }
+  function fmtRate(v){ return RATE.format(Number.isFinite(v) ? v : 0) + ' /kWh'; }
 
-pdfMake.fonts = {
-  Roboto: {
-    normal: 'Roboto-Regular.ttf',
-    bold: 'Roboto-Medium.ttf',
-    italics: 'Roboto-Italic.ttf',
-    bolditalics: 'Roboto-MediumItalic.ttf'
-  },
-  NotoDeva: {
-    normal: 'NotoSansDevanagari-Regular.ttf',
-    bold: 'NotoSansDevanagari-Bold.ttf'
+  function generateIOMPDF(model, monthLabel){
+    if(!global.pdfMake){ console.error('pdfMake not loaded'); return; }
+    const docDefinition = {
+      content: [
+        { text: `WEG Billing – ${monthLabel}`, style: 'header' },
+        { text: 'HT Bill', style: 'subheader', margin: [0, 10, 0, 4] },
+        {
+          style: 'table',
+          table: {
+            widths: ['*', 'auto'],
+            body: [
+              ['Monthly Consumption', fmtKwh(model.A4) + ' kWh'],
+              ['Demand Charges', fmtCurrency(model.B4)],
+              ['Energy Charges', fmtCurrency(model.C4)],
+              ['Night Rebate', fmtCurrency(model.D4)],
+              ['Fuel Charge', fmtCurrency(model.E4)],
+              ['PF Rebate', fmtCurrency(model.F4)],
+              ['EHV Rebate', fmtCurrency(model.G4)],
+              ['TOU', fmtCurrency(model.H4)],
+              ['GT Charges', fmtCurrency(model.I4)],
+              ['Total Consumption Charge', fmtCurrency(model.A9)],
+              ['ED @ 20%', fmtCurrency(model.B9)],
+              ['Current Month Bill', fmtCurrency(model.C9)]
+            ]
+          }
+        },
+        { text: 'Adjustments', style: 'subheader', margin: [0, 10, 0, 4] },
+        {
+          style: 'table',
+          table: {
+            widths: ['*', 'auto'],
+            body: [
+              ['Outstanding Arrears', fmtCurrency(model.D9)],
+              ['Freeze Amount', fmtCurrency(model.E9)],
+              ['Delayed Payment Charges', fmtCurrency(model.F9)],
+              ['Advance Payment / Adjust.', fmtCurrency(model.G9)],
+              ['Net Payable', fmtCurrency(model.H9)],
+              ['Actual Amount to be Paid', fmtCurrency(model.I9)],
+              ['Balance Pending from Previous Month', fmtCurrency(model.A31)]
+            ]
+          }
+        },
+        { text: 'WEG Shares', style: 'subheader', margin: [0, 10, 0, 4] },
+        {
+          style: 'table',
+          table: {
+            widths: ['*', 'auto'],
+            body: [
+              ['Bitlavadia Share', fmtKwh(model.A18) + ' kWh'],
+              ['Nanisindhodi Share', fmtKwh(model.C18) + ' kWh'],
+              ['Total Allocated', fmtKwh(model.A19) + ' kWh']
+            ]
+          }
+        },
+        { text: 'Wind Credits / Debits', style: 'subheader', margin: [0, 10, 0, 4] },
+        {
+          style: 'table',
+          table: {
+            widths: ['*', 'auto'],
+            body: [
+              ['Total Credit', fmtCurrency(model.A26)],
+              ['Total Debit', fmtCurrency(model.B26)],
+              ['Net Wind Credit', fmtCurrency(model.C26)]
+            ]
+          }
+        },
+        { text: 'Rates & Allocation', style: 'subheader', margin: [0, 10, 0, 4] },
+        {
+          style: 'table',
+          table: {
+            widths: ['*', 'auto'],
+            body: [
+              ['Wind Rate', fmtRate(model.B19)],
+              ['Share 4.5 MW', fmtCurrency(model.F16)],
+              ['Share 14.7 MW', fmtCurrency(model.G16)]
+            ]
+          }
+        },
+        { text: 'Final', style: 'subheader', margin: [0, 10, 0, 4] },
+        {
+          style: 'table',
+          table: {
+            widths: ['*', 'auto'],
+            body: [
+              ['Final Bill for IOM', fmtCurrency(model.FINAL)]
+            ]
+          }
+        }
+      ],
+      styles: {
+        header: { fontSize: 16, bold: true, alignment: 'center' },
+        subheader: { fontSize: 13, bold: true },
+        table: { margin: [0, 0, 0, 4] }
+      },
+      defaultStyle: { fontSize: 10 }
+    };
+    global.pdfMake.createPdf(docDefinition).download(`IOM_${monthLabel}.pdf`);
   }
-};
 
-const docDefinition = {
-  defaultStyle: { font: 'Roboto' },
-  content: [
-    { text: 'Sample English text rendered with Roboto.' },
-    { text: 'यह हिंदी पाठ है', style: 'hindi' }
-  ],
-  styles: {
-    hindi: { font: 'NotoDeva' }
-  }
-};
-
-pdfMake.createPdf(docDefinition);
+  global.generateIOMPDF = generateIOMPDF;
+  global.__iomPdfFmt = { fmtCurrency, fmtKwh, fmtMwh, fmtRate };
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- expose generateIOMPDF that builds an IOM memo PDF using pdfMake
- add helpers for currency, kWh, MWh, and ₹/kWh formatting and apply across tables
- load IOM PDF script in the main HTML page

## Testing
- `node -e "require('./iom-pdf.js'); console.log('ok');"`


------
https://chatgpt.com/codex/tasks/task_e_689eee72c8c88333a0ebfe8b03d645a6