### PR TITLE
Refactor pdf generation with blob API and save dialog

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -865,10 +865,28 @@
       $('downloadPDF').addEventListener('click', () => withBusy('downloadPDF', async () => {
         const model = compute(true);
         if (!model) { toast('Cannot download: fix inputs first.', 'warn'); return; }
+        const label = monthLabel();
+        const canSavePicker = !!(window.showSaveFilePicker) && isSecureContext;
 
         try {
-          window.generateIOMPDF(model, monthLabel());
-          toast('IOM PDF downloaded.', 'good');
+          if (canSavePicker) {
+            const blob = await generateIOMPDFBlob(model, label);
+            const handle = await window.showSaveFilePicker({
+              suggestedName: `IOM_${label}.pdf`,
+              types: [{ description: 'PDF', accept: { 'application/pdf': ['.pdf'] } }]
+            });
+            const ws = await handle.createWritable();
+            await ws.write(blob);
+            await ws.close();
+            toast('IOM PDF saved to the chosen location.', 'good');
+          } else {
+            generateIOMPDF(model, label);
+            if (location.protocol === 'file:') {
+              toast('Your browser saved the PDF to its default Downloads folder. For a Save As dialog, open this file via http://localhost or HTTPS.', 'info');
+            } else {
+              toast('PDF saved to your browser’s default download location. Enable “Ask where to save each file” to choose a folder.', 'info');
+            }
+          }
         } catch (e) {
           console.error(e);
           toast('PDF generation failed. See console for details.', 'bad');

--- a/iom-pdf.js
+++ b/iom-pdf.js
@@ -25,8 +25,7 @@
   function fmtMwh(v){ return MWH.format(Number.isFinite(v) ? v : 0); }
   function fmtRate(v){ return RATE.format(Number.isFinite(v) ? v : 0) + ' /kWh'; }
 
-  global.generateIOMPDF = function generateIOMPDF(model, monthStr){
-    if(!global.pdfMake){ console.error('pdfMake not loaded'); return; }
+  function buildIOMDocDefinition(model, monthStr){
     const vendorLines = model.vendorLines || [];
     const bankLines = model.bankLines || [];
     const content = [
@@ -134,7 +133,7 @@
       });
     }
 
-    const docDefinition = {
+    return {
       content,
       styles: {
         header: { fontSize: 16, bold: true, alignment: 'center' },
@@ -144,7 +143,28 @@
       },
       defaultStyle: { font: 'Noto', fontSize: 10 }
     };
-    global.pdfMake.createPdf(docDefinition).download(`IOM_${monthStr}.pdf`);
-  };
+  }
+
+  function generateIOMPDF(model, monthStr){
+    if(!global.pdfMake){ console.error('pdfMake not loaded'); return; }
+    global.pdfMake.createPdf(buildIOMDocDefinition(model, monthStr)).download(`IOM_${monthStr}.pdf`);
+  }
+
+  function generateIOMPDFOpen(model, monthStr){
+    if(!global.pdfMake){ console.error('pdfMake not loaded'); return; }
+    global.pdfMake.createPdf(buildIOMDocDefinition(model, monthStr)).open();
+  }
+
+  function generateIOMPDFBlob(model, monthStr){
+    if(!global.pdfMake){ console.error('pdfMake not loaded'); return Promise.reject(new Error('pdfMake not loaded')); }
+    return new Promise(resolve => {
+      global.pdfMake.createPdf(buildIOMDocDefinition(model, monthStr)).getBlob(resolve);
+    });
+  }
+
+  global.buildIOMDocDefinition = buildIOMDocDefinition;
+  global.generateIOMPDF = generateIOMPDF;
+  global.generateIOMPDFOpen = generateIOMPDFOpen;
+  global.generateIOMPDFBlob = generateIOMPDFBlob;
   global.__iomPdfFmt = { fmtCurrency, fmtKwh, fmtMwh, fmtRate };
 })(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- Extract PDF doc builder into `buildIOMDocDefinition` and expose new helpers to download, open, or get PDF Blob
- Enhance GUI to use system Save As dialog when available, with fallbacks and clearer toasts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f31798888833388fbb35607f17ae3