### PR TITLE
Add local pdfMake assets for offline PDF export

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -284,6 +284,23 @@
   <!-- SheetJS for Excel export -->
   <!-- Prefer a local copy for offline/file:// usage; keep dynamic loader as fallback -->
   <script src="./xlsx.full.min.js"></script>
+  <!-- pdfMake and fonts for PDF export (local, offline) -->
+  <script src="./pdfmake.min.js"></script>
+  <script src="./vfs_fonts.js"></script>
+  <script type="module">
+    import vfs from './vfs_noto_deva.js';
+    if (window.pdfMake && vfs) {
+      window.pdfMake.vfs   = Object.assign({}, window.pdfMake.vfs || {}, vfs);
+      window.pdfMake.fonts = Object.assign({}, window.pdfMake.fonts || {}, {
+        Noto: {
+          normal: 'NotoSansDevanagari-Regular.ttf',
+          bold:   'NotoSansDevanagari-Bold.ttf',
+          italics: 'NotoSansDevanagari-Regular.ttf',
+          bolditalics: 'NotoSansDevanagari-Bold.ttf'
+        }
+      });
+    }
+  </script>
   <script>
     function toast(msg, type='info'){
       const t = document.createElement('div');


### PR DESCRIPTION
## Summary
- add local pdfMake and font resources for offline PDF creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fe14f6c5c833383b640e6348a323c