### PR TITLE
chore: log script load failures

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -361,7 +361,10 @@
         s.async = true;
         s.dataset.src = src;
         s.onload = resolve;
-        s.onerror = reject;
+        s.onerror = (e) => {
+          console.error('[PDF] Failed to load', src, e);
+          reject(e);
+        };
         document.head.appendChild(s);
       });
     }


### PR DESCRIPTION
## Summary
- add console logging in `__loadScriptOnce` when a script fails to load
- confirm existing `ensurePDFReady` callers await `__loadScriptOnce` for PDF resources

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fe236c6788333b9eaaf83e33dfad1