### PR TITLE
Check for Noto fonts and fall back to Roboto

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -360,6 +360,10 @@
         toast('PDF fonts/VFS not loaded. Include ./vfs_fonts.js (and Noto VFS if needed).', 'bad');
         return false;
       }
+      if (!pdfMake.fonts?.Noto) {
+        toast('Noto fonts are not registered.', 'bad');
+        return false;
+      }
       if (typeof window.generateIOMPDF !== 'function') {
         toast('PDF template (iom-pdf.js) not loaded.', 'bad');
         return false;

--- a/iom-pdf.js
+++ b/iom-pdf.js
@@ -1025,6 +1025,7 @@
       });
     }
 
+    const defaultFont = global.pdfMake?.fonts?.Noto ? 'Noto' : 'Roboto';
     return {
       content,
       styles: {
@@ -1033,7 +1034,7 @@
         table: { margin: [0, 0, 0, 4] },
         bank: { fillColor: '#ffff00', color: 'black', bold: true }
       },
-      defaultStyle: { font: 'Noto', fontSize: 10 }
+      defaultStyle: { font: defaultFont, fontSize: 10 }
     };
   }
 


### PR DESCRIPTION
## Summary
- verify Noto font registration before generating PDF and warn user when missing
- fall back to Roboto font when Noto isn't available for PDF generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0011ea4a483339154d9cc81730680