### PR TITLE
Remove Noto font merging from pdfMake setup

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -287,48 +287,6 @@
   <!-- pdfMake and fonts for PDF export (local, offline) -->
   <script src="./pdfmake.min.js"></script>
   <script src="./vfs_fonts.js"></script>
-  <script src="./vfs_noto_deva.js"></script> <!-- optional -->
-
-<script>
-(function ensurePdfVfsOnce(){
-  if (!window.pdfMake || window.__VFS_MERGED) return;
-
-  // 1) Merge base Roboto VFS (from vfs_fonts.js) + optional Noto VFS
-  if (window.vfs)      pdfMake.vfs = Object.assign({}, pdfMake.vfs || {}, window.vfs);
-  if (window.NOTO_VFS) pdfMake.vfs = Object.assign({}, pdfMake.vfs || {}, window.NOTO_VFS);
-
-  // 2) Register font families using exact keys that exist in vfs
-  var hasRoboto = !!(pdfMake.vfs && pdfMake.vfs['Roboto-Regular.ttf']);
-  var hasNoto   = !!(pdfMake.vfs && (pdfMake.vfs['NotoSansDevanagari-Regular.ttf'] || pdfMake.vfs['NotoSansDevanagari-Bold.ttf']));
-
-  if (hasRoboto) {
-    pdfMake.fonts = Object.assign({}, pdfMake.fonts || {}, {
-      Roboto: {
-        normal:      'Roboto-Regular.ttf',
-        bold:        'Roboto-Medium.ttf',
-        italics:     'Roboto-Italic.ttf',
-        bolditalics: 'Roboto-Italic.ttf'
-      }
-    });
-  }
-
-  // Prefer Noto if present; otherwise alias Noto → Roboto so { font: 'Noto' } never crashes
-  if (hasNoto) {
-    pdfMake.fonts = Object.assign({}, pdfMake.fonts, {
-      Noto: {
-        normal:      'NotoSansDevanagari-Regular.ttf',
-        bold:        'NotoSansDevanagari-Bold.ttf',
-        italics:     'NotoSansDevanagari-Regular.ttf',
-        bolditalics: 'NotoSansDevanagari-Bold.ttf'
-      }
-    });
-  } else if (pdfMake.fonts && pdfMake.fonts.Roboto) {
-    pdfMake.fonts.Noto = pdfMake.fonts.Roboto;
-  }
-
-  window.__VFS_MERGED = true;
-})();
-</script>
 
 <script src="./iom-pdf.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- Drop optional Noto font bundle and VFS merge logic from `1.4.1 GUI Entry.html`
- Leave only `pdfmake.min.js` and `vfs_fonts.js` for PDF generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a06aa121448333a708ff147bbbed60