### PR TITLE
refine PDF readiness logging

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -303,10 +303,9 @@
   </script>
   <script>
 document.addEventListener('DOMContentLoaded', () => {
-  var hasPdfMake = !!window.pdfMake;
-  var vfsCount   = hasPdfMake && pdfMake.vfs ? Object.keys(pdfMake.vfs).length : 0;
-  var hasNoto    = hasPdfMake && pdfMake.fonts && !!pdfMake.fonts.Noto;
-  console.log('[PDF] ready?:', { hasPdfMake, vfsCount, hasNoto });
+  const hasPdfMake = !!window.pdfMake;
+  const vfsCount = hasPdfMake && pdfMake.vfs ? Object.keys(pdfMake.vfs).length : 0;
+  console.log('[PDF] ready?', { hasPdfMake, vfsCount });
 });
 </script>
   <script>


### PR DESCRIPTION
## Summary
- simplify DOMContentLoaded PDF logging to report `hasPdfMake` and `vfsCount`
- keep `pdfReady` checks for pdfMake, virtual filesystem, and PDF template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a06bb54a0083339b9f6ca0a3a47037