### PR TITLE
style: condense toolbar and header spacing

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -33,7 +33,7 @@
                   var(--bg);
       color:var(--ink);
     }
-    .wrap{max-width:1200px;margin:32px auto;padding:0 20px}
+    .wrap{max-width:1200px;margin:20px auto;padding:0 20px}
     header{
       position:sticky;top:0;z-index:10;
       backdrop-filter:saturate(150%) blur(8px);
@@ -42,16 +42,25 @@
       display:grid;
       grid-template-columns:minmax(260px,auto) 1fr;
       align-items:start;
-      gap:16px;
-      margin-bottom:18px;
+      gap:10px;
+      margin-bottom:10px;
+      padding:6px 0;               /* slimmer top bar */
     }
+
+    .brand svg{width:26px;height:26px}
+    .brand h1{font-size:18px;line-height:1.2}
+    .sub{font-size:12px;margin-top:2px}
+
     .brand{display:flex;align-items:center;gap:12px}
-    .brand svg{width:34px;height:34px}
-    .brand h1{margin:0;font-size:22px;letter-spacing:.3px}
-    .sub{color:var(--ink);font-size:13.5px}
+    .brand h1{margin:0;letter-spacing:.3px}
+    .sub{color:var(--ink)}
 
     button, .ghost{
-      border:0;border-radius:12px;padding:10px 14px;font-weight:600;letter-spacing:.2px;
+      border:0;border-radius:10px;padding:6px 10px;font-size:13px;font-weight:600;letter-spacing:.2px;
+      line-height:1.1;               /* compact but readable */
+      min-height:34px;               /* a11y tap target */
+      white-space:nowrap;            /* prevent multi-line buttons */
+      max-width:100%;
       background:linear-gradient(145deg, rgba(167,139,250,.25), rgba(34,211,238,.25));
       color:white;cursor:pointer;box-shadow:var(--shadow);backdrop-filter: blur(6px);
     }
@@ -113,10 +122,26 @@
     .muted{color:var(--muted)}
     .hr{height:1px;background:linear-gradient(90deg, rgba(255,255,255,.15), rgba(255,255,255,.03));margin:14px 0}
 
-    .pill{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.08);font-size:12px}
-    .pill button{padding:2px 8px}
+    .pill{display:inline-flex;align-items:center;gap:8px;padding:4px 6px;border-radius:999px;
+      background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.08);font-size:11px;
+      min-height:34px}
+    /* keep pill text on one line, truncate gracefully */
+    .pill > span{white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:100%;}
+    .pill button{padding:2px 6px}
     .pills{display:flex;gap:6px;flex-wrap:wrap}
     .right{float:right}
+
+    /* Normalize header form-control height to match 34px tap target */
+    header .toolbar input[type="month"],
+    header .toolbar input[type="text"],
+    header .toolbar select{
+      height:34px; line-height:34px;
+      padding:0 10px; font-size:13px;
+      border-radius:8px; /* harmonize with pill rounding */
+    }
+      header .toolbar input{margin:0}  /* avoid UA default margins increasing pill height */
+      header .toolbar input[type="checkbox"]{height:auto;width:auto} /* keep checkbox natural */
+
 
     details{margin:10px 0}
     summary{cursor:pointer}
@@ -136,29 +161,39 @@
     /* Toolbar group layout */
     header .toolbar{ grid-column:1 / -1; }
     .toolbar{
-      display:flex; flex-wrap:wrap; gap:12px; align-items:center;
+      display:flex; flex-wrap:wrap; gap:8px; align-items:center;
       overflow:hidden; min-width:0;
-      padding:8px 0;
+      padding:4px 0;
     }
-    .toolbar .pill{min-width:0;}
+    /* pills in toolbar should not cause overflow */
+    .toolbar .pill{min-width:0; max-width:100%;}
     .group{
-      display:flex; align-items:center; gap:10px;
-      padding:8px 10px;
-      border-radius:999px;
+      display:flex; align-items:center; gap:6px;
+      padding:3px 6px;                /* slightly tighter */
+      border-radius:12px;
       background:rgba(255,255,255,.05);
       border:1px solid rgba(255,255,255,.08);
-      flex-wrap:wrap; flex:1 1 420px; min-width:280px; max-width:100%;
+      flex-wrap:wrap; flex:1 1 340px; min-width:240px; max-width:100%;
     }
     .group .label{
-      font-size:11px; letter-spacing:.06em; text-transform:uppercase;
+      font-size:10px; letter-spacing:.05em; text-transform:uppercase;
       color:var(--muted); margin-right:2px;
-      min-width:90px;
+      min-width:90px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+      max-width:120px;
     }
+    .group[aria-label="Utilities"]{padding:2px 4px;gap:4px}
     /* Compact on narrow screens */
     @media (max-width: 980px){
       header{ grid-template-columns: 1fr; }
       .group{ width:100%; border-radius:14px; }
       .toolbar > label.pill{ width:100%; }
+    }
+
+    /* Encourage earlier wrapping on mid-width laptops to keep header compact */
+    @media (max-width: 1280px) and (min-width: 1060px){
+      .group{
+        flex:1 1 300px;
+      }
     }
 
     /* A4 page layout for HTML preview */


### PR DESCRIPTION
## Summary
- condense header spacing and shrink brand elements for a slimmer top bar
- standardize form controls and pills to 34px height with ellipsis truncation to avoid overflow
- encourage mid-width wrapping to keep groups tidy and the header compact

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b4e7b94883339e7dea734cc91b3d