### PR TITLE
feat: add IOM HT Bill light pdf

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>WEG Billing Calculator</title>
+  <title>IOM - HT Bill Calculator</title>
   <!-- Main styles including print rules; id must remain unique -->
   <style id="print-css">
     :root{
@@ -22,6 +22,8 @@
       --shadow: 0 20px 50px rgba(0,0,0,.45);
       --radius: 18px;
     }
+    /* Force a light palette for export */
+    :root { color-scheme: light only; }
     *{box-sizing:border-box}
     :focus-visible{outline:var(--ring);outline-offset:2px}
     html,body{height:100%}
@@ -209,9 +211,13 @@
       font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
     }
 
-    .doc-header { display:flex; justify-content:space-between; align-items:flex-end; margin-bottom:8mm; }
-    .doc-header h2 { margin:0; font-size:18pt; }
+    .doc-header { display:flex; justify-content:space-between; align-items:flex-end; margin-bottom:4mm; }
+    .doc-header h2 { margin:2mm 0 0; font-size:18pt; }
+    .doc-header .company { font-weight:700; }
+    .doc-header .dept { font-size:11pt; }
     .doc-meta { color:#555; font-size:10.5pt; text-align:right; }
+    .info-bar { background:#f3f4f6; border:1px solid #e5e7eb; padding:2mm 4mm; margin-bottom:8mm; font-size:10.5pt; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+    @media print { .info-bar { overflow:visible; text-overflow:clip; } }
     .sec { break-inside: avoid; margin: 7mm 0 0; }
     .sec h3 { margin:0 0 3mm; font-size:12pt; border-bottom:1px solid #ddd; padding-bottom:2.5mm; }
     .kv { display:grid; grid-template-columns: 1fr minmax(52mm,auto) 10mm; gap:2mm; padding:2mm 0; border-bottom:1px dashed #eee; }
@@ -235,7 +241,7 @@
     @media print {
       @page { size: A4; margin: 14mm; }
       header, .toolbar, .card:not(.sheet), #toasts { display:none !important; }
-      .sheet { display:block !important; border:none; width:auto; min-height:auto; margin:0; padding:0; page-break-after:always;
+      .sheet { display:block !important; border:none; width:auto; min-height:auto; margin:0; padding:0 0 22mm 0; page-break-after:always;
                -webkit-print-color-adjust: exact; print-color-adjust: exact; }
       .sheet:last-child { page-break-after:auto; }
     }
@@ -733,20 +739,28 @@
       const el = document.createElement('div');
       el.className = 'sheet';
       const meta = generatedAt || new Date().toLocaleString();
+      const metaISO = (() => { try { const d = generatedAt ? new Date(generatedAt) : new Date(); return isNaN(d) ? new Date().toISOString() : d.toISOString(); } catch { return new Date().toISOString(); } })();
       // Do not read from model: hard-coded by policy (see Stability Guard above).
       const vendorCode = SAP_VENDOR_CODE;
       const bankT = SAP_BANKT;
+      try { document.title = `IOM - HT Bill – ${monthLabel}`; } catch {}
       el.innerHTML = `
         <div class="doc-header">
-          <div><h2>WEG IOM Statement</h2>
+          <div>
+            <div class="company">GAIL (India) Limited – Samakhiali, Gujarat</div>
+            <div class="dept">Electrical Department</div>
+            <h2 role="heading" aria-level="1">IOM - HT Bill</h2>
             <div class="mini">Billing Month: <b>${monthLabel}</b></div>
           </div>
           <div class="doc-meta">
-            Generated: <b>${meta}</b><br/>
-            SAP Vendor Code: <b data-testid="sap-vendor-code">${vendorCode}</b><br/>
-            SAP BankT: <b data-testid="sap-bankt">${bankT}</b>
+            Generation Date: <b><time datetime="${metaISO}">${meta}</time></b>
           </div>
         </div>
+        <div
+          class="info-bar"
+          title="Please pay to Paschim Gujarat Vij Company Ltd (Vendor Code: ${vendorCode}). Bank A/C No.: 31729314272; RTGS/NEFT IFSC: SBIN0000554; Branch: SBI – Bhachau"
+          aria-label="Please pay to Paschim Gujarat Vij Company Ltd (Vendor Code: ${vendorCode}). Bank A/C No.: 31729314272; RTGS/NEFT IFSC: SBIN0000554; Branch: SBI – Bhachau"
+        >Please pay to <b>Paschim&nbsp;Gujarat&nbsp;Vij&nbsp;Company&nbsp;Ltd</b> (Vendor Code: <b>${vendorCode}</b>). Bank A/C No.: <b>31729314272</b>; RTGS/NEFT IFSC: <b>SBIN0000554</b>; Branch: <b>SBI – Bhachau</b></div>
         <section class="sec">
           <h3>Remittance Details</h3>
           <div class="kv"><div class="label">Payee</div><div class="value">Paschim Gujarat Vij Company Ltd</div><div class="unit"></div></div>
@@ -819,6 +833,11 @@
         </section>
         <div class="footer-note" style="margin-top:6mm;">Keep this PDF with the source data for audit.</div>
         <div class="page-number" aria-hidden="true">Page 1</div>`;
+      // Accessibility: hide decorative page number from AT if present
+      try {
+        const pn = el.querySelector('.page-number');
+        if (pn) pn.setAttribute('aria-hidden','true');
+      } catch {}
       return el;
     }
 
@@ -1293,8 +1312,10 @@
 body{margin:0;font:14px system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#111}
 .sheet{width:210mm;min-height:297mm;padding:16mm 18mm 22mm;position:relative}
 .doc-header{display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:8mm}
-.doc-header .left h2{margin:0;font-size:18pt}
+.doc-header h2{margin:2mm 0 0;font-size:18pt}
 .doc-meta{color:#555;font-size:10.5pt;text-align:right}
+.info-bar{background:#f3f4f6;border:1px solid #e5e7eb;padding:2mm 4mm;margin-bottom:8mm;font-size:10.5pt;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+@media print{.info-bar{overflow:visible;text-overflow:clip}}
 .sec{break-inside:avoid;margin:7mm 0 0}
  .sec h3{margin:0 0 3mm;font-size:12pt;border-bottom:1px solid #ddd;padding-bottom:2.5mm}
  .kv{display:grid;grid-template-columns:1fr minmax(52mm,auto) 10mm;gap:2mm;padding:2mm 0;border-bottom:1px dashed #eee}
@@ -1302,9 +1323,9 @@ body{margin:0;font:14px system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,
  .signatures{break-inside:avoid} .sigs{display:grid;grid-template-columns:1fr 1fr;gap:6mm;margin-top:6mm}.sig{text-align:left}.sig.right{text-align:right}.sig .line{border-top:1px solid #d1d5db;height:0;margin:14mm 0 2mm}.sig .role{color:#111;font-weight:600}
  .footer-note{margin-top:8mm;color:#6b7280;font-size:9.5pt}.page-number{position:absolute;bottom:8mm;right:18mm;color:#6b7280;font-size:10pt}`;
         const css = cssElem ? cssElem.innerHTML : fallbackCss;
-        const month = (host.dataset && host.dataset.monthLabel) ? ` - ${host.dataset.monthLabel}` : '';
+        const month = (host.dataset && host.dataset.monthLabel) ? ` – ${host.dataset.monthLabel}` : '';
         const html = `
-    <!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="color-scheme" content="light"><title>WEG Billing PDF${month}</title>
+    <!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="color-scheme" content="light"><title>IOM - HT Bill${month}</title>
     <style>${css}</style>
     <script>window.addEventListener('afterprint',()=>{ try{ window.close(); }catch(_){} });<\/script>
     </head><body onload="setTimeout(()=>window.print(),100)">${host.innerHTML}</body></html>`;

--- a/scripts/smoke.test.js
+++ b/scripts/smoke.test.js
@@ -10,11 +10,9 @@ test('SAP identifiers are hard-coded and ignore model overrides', () => {
 
   const withOverrides = { C9:1,F16:2,G16:3,C24:4,A31:5,F9:6,FINAL:7, vendorCode:'VCODE', bankT:'BANK1' };
   const el1 = window.buildIomStatementHtml(withOverrides, 'Jan', '2024-04-01');
-  assert.equal(el1.querySelector('[data-testid="sap-vendor-code"]').textContent, 'ZG0435');
-  assert.equal(el1.querySelector('[data-testid="sap-bankt"]').textContent, 'SBI1');
+  assert.match(el1.querySelector('.info-bar').textContent, /Vendor Code:\s*ZG0435/);
 
   const withoutOverrides = { C9:1,F16:2,G16:3,C24:4,A31:5,F9:6,FINAL:7 };
   const el2 = window.buildIomStatementHtml(withoutOverrides, 'Jan', '2024-04-01');
-  assert.equal(el2.querySelector('[data-testid="sap-vendor-code"]').textContent, 'ZG0435');
-  assert.equal(el2.querySelector('[data-testid="sap-bankt"]').textContent, 'SBI1');
+  assert.match(el2.querySelector('.info-bar').textContent, /Vendor Code:\s*ZG0435/);
 });

--- a/test/header.spec.js
+++ b/test/header.spec.js
@@ -1,0 +1,56 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const {JSDOM} = require('jsdom');
+
+test('header and remittance bar render correctly', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', '1.4.1 GUI Entry.html'), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'https://example.org' });
+  const el = dom.window.buildIomStatementHtml({FINAL:0}, 'Jan', '2025-01-01');
+  // Title should be set for export naming
+  assert.equal(dom.window.document.title, 'IOM - HT Bill – Jan');
+
+  const h2 = el.querySelector('.doc-header h2');
+  assert.equal(h2.textContent.trim(), 'IOM - HT Bill');
+  assert.equal(el.querySelector('.doc-header .company').textContent.trim(), 'GAIL (India) Limited – Samakhiali, Gujarat');
+  assert.equal(el.querySelector('.doc-header .dept').textContent.trim(), 'Electrical Department');
+  assert.equal(el.querySelector('.doc-header .mini').textContent.trim(), 'Billing Month: Jan');
+
+  const metaBlock = el.querySelector('.doc-meta');
+  const meta = metaBlock.textContent;
+  assert.match(meta, /Generation Date:\s*2025-01-01/);
+  assert.ok(!/Vendor Code:/i.test(meta), 'Header must not show Vendor Code');
+  assert.ok(!/BankT:/i.test(meta), 'Header must not show BankT');
+  const time = metaBlock.querySelector('time');
+  assert.ok(time, 'Generation Date should use <time>');
+  assert.ok(time.getAttribute('datetime'), 'time element requires datetime attribute');
+  assert.match(time.getAttribute('datetime'), /^\d{4}-\d{2}-\d{2}T/, 'datetime should be ISO-8601-like (YYYY-MM-DDT...)');
+
+  // Heading semantics for assistive tech
+  assert.equal(h2.getAttribute('role'), 'heading', 'Title should expose role=heading');
+  assert.equal(h2.getAttribute('aria-level'), '1', 'Title should expose aria-level=1');
+
+  // Defensive: ensure old test IDs are not reintroduced in the header
+  assert.ok(!el.querySelector('.doc-header [data-testid="sap-vendor-code"]'), 'sap-vendor-code test id must not appear in header');
+  assert.ok(!el.querySelector('.doc-header [data-testid="sap-bankt"]'), 'sap-bankt test id must not appear in header');
+
+  const bar = el.querySelector('.info-bar');
+  assert.ok(bar);
+  assert.equal(bar.querySelectorAll('b').length, 5);
+  assert.match(bar.textContent, /Please pay to/);
+  assert.match(bar.textContent, /Vendor Code:\s*ZG0435/);
+  // Ensure NBSPs to keep payee on one line
+  assert.match(bar.innerHTML, /Paschim&nbsp;Gujarat&nbsp;Vij&nbsp;Company&nbsp;Ltd/);
+  // Full-text discoverability while truncated
+  assert.ok(bar.getAttribute('title') && bar.getAttribute('title').trim().length > 0, 'info-bar should expose full text via title');
+  assert.ok(bar.getAttribute('aria-label') && bar.getAttribute('aria-label').trim().length > 0, 'info-bar should expose full text via aria-label');
+
+  // Decorative page number should be hidden from AT
+  const pageNum = el.querySelector('.page-number');
+  assert.ok(pageNum && pageNum.getAttribute('aria-hidden') === 'true', 'page number should be aria-hidden');
+
+  // Quick guard that print CSS reserves footer space
+  const cssSource = html.toString();
+  assert.ok(cssSource.includes('padding:0 0 22mm 0'), 'Print padding for footer must exist');
+});

--- a/test/receipt-and-sap.spec.js
+++ b/test/receipt-and-sap.spec.js
@@ -11,6 +11,5 @@ test('receipt note present and SAP constants immutable', () => {
   const el = dom.window.buildIomStatementHtml(model, 'Jan', '2025-01-01');
   const note = el.querySelector('[data-testid="receipt-note"]');
   assert.equal(note && note.textContent.trim(), 'Bill received via central post.');
-  assert.equal(el.querySelector('[data-testid="sap-vendor-code"]').textContent.trim(), 'ZG0435');
-  assert.equal(el.querySelector('[data-testid="sap-bankt"]').textContent.trim(), 'SBI1');
+  assert.match(el.querySelector('.info-bar').textContent, /Vendor Code:\s*ZG0435/);
 });

--- a/test/static-title.spec.js
+++ b/test/static-title.spec.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+test('static head title and fallback info-bar rule are present', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', '1.4.1 GUI Entry.html'), 'utf8');
+  // Static <title> should be aligned with product naming
+  assert.ok(
+    /<title>\s*IOM\s*-\s*HT\s*Bill\s*Calculator\s*<\/title>/i.test(src),
+    'Static <title> must be "IOM - HT Bill Calculator"'
+  );
+  // Fallback CSS must include .info-bar styling (single line + ellipsis)
+  assert.ok(
+    /\.info-bar\{[^}]*white-space:nowrap;[^}]*text-overflow:ellipsis/si.test(src),
+    'Fallback CSS must style .info-bar for nowrap + ellipsis'
+  );
+  // Fallback CSS must style the document title using the current selector
+  assert.ok(
+    /\.doc-header\s*h2\{[^}]*font-size:\s*18pt/si.test(src),
+    'Fallback CSS must style .doc-header h2 (not the obsolete .doc-header .left h2)'
+  );
+
+  // Primary #print-css must lock light scheme (prevent dark-mode inversion)
+  const cssBlockMatch = src.match(/<style\s+id=["']print-css["'][^>]*>([\s\S]*?)<\/style>/i);
+  assert.ok(cssBlockMatch, 'Primary #print-css block should exist');
+  const cssBlock = cssBlockMatch[1];
+  assert.ok(
+    /:root\s*\{\s*color-scheme:\s*light\s+only\s*;?/i.test(cssBlock),
+    'Primary #print-css must include :root { color-scheme: light only; }'
+  );
+
+  // Export HTML template must explicitly set color-scheme meta to light
+  assert.ok(/<meta\s+name=["']color-scheme["']\s+content=["']light["']\s*>/i.test(src), 'Export HTML must set color-scheme=light');
+
+  // Primary print CSS (#print-css) should also enforce nowrap + ellipsis on .info-bar
+  assert.ok(
+    /\.info-bar\s*\{[^}]*white-space:\s*nowrap;[^}]*text-overflow:\s*ellipsis/si.test(cssBlock),
+    'Primary #print-css must style .info-bar for nowrap + ellipsis'
+  );
+
+  // Fallback export window must set its own title correctly
+  assert.ok(
+    /<title>\s*IOM\s*-\s*HT\s*Bill\$\{month\}\s*<\/title>/i.test(src),
+    'Fallback export HTML <title> must start with "IOM - HT Bill"'
+  );
+});


### PR DESCRIPTION
## Summary
- align static head title with dynamic export title
- hide decorative page numbers from assistive tech
- set print window title for IOM HT Bill PDFs
- remove vendor code and bankT from header and guard tests
- style remittance bar in fallback CSS and wrap generation date in `<time>`
- expose full remittance text via title and aria-label and harden fallback header styling
- add test to check static title and fallback info-bar rule
- test remittance bar accessibility attributes and fallback `.doc-header h2` rule
- assert primary print CSS keeps remittance bar single line and fallback print window titled for IOM HT Bill
- validate ISO datetime, heading semantics, and absence of SAP test IDs in header
- guard light-only color scheme, match fallback title margin, and ensure page number stays hidden from AT

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a28eaa1ffc8333b7f936fe0d0f1482