### PR TITLE
Remove remittance table and allow info bar wrapping

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -216,7 +216,7 @@
     .doc-header .company { font-weight:700; }
     .doc-header .dept { font-size:11pt; }
     .doc-meta { color:#555; font-size:10.5pt; text-align:right; }
-    .info-bar { background:#f3f4f6; border:1px solid #e5e7eb; padding:2mm 4mm; margin-bottom:8mm; font-size:10.5pt; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+    .info-bar { background:#f3f4f6; border:1px solid #e5e7eb; padding:2mm 4mm; margin-bottom:8mm; font-size:10.5pt; white-space:normal; overflow:visible; text-overflow:clip; overflow-wrap:anywhere; word-break:break-word; }
     @media print { .info-bar { overflow:visible; text-overflow:clip; } }
     .sec { break-inside: avoid; margin: 7mm 0 0; }
     .sec h3 { margin:0 0 3mm; font-size:12pt; border-bottom:1px solid #ddd; padding-bottom:2.5mm; }
@@ -761,13 +761,6 @@
           title="Please pay to Paschim Gujarat Vij Company Ltd (Vendor Code: ${vendorCode}). Bank A/C No.: 31729314272; RTGS/NEFT IFSC: SBIN0000554; Branch: SBI – Bhachau"
           aria-label="Please pay to Paschim Gujarat Vij Company Ltd (Vendor Code: ${vendorCode}). Bank A/C No.: 31729314272; RTGS/NEFT IFSC: SBIN0000554; Branch: SBI – Bhachau"
         >Please pay to <b>Paschim&nbsp;Gujarat&nbsp;Vij&nbsp;Company&nbsp;Ltd</b> (Vendor Code: <b>${vendorCode}</b>). Bank A/C No.: <b>31729314272</b>; RTGS/NEFT IFSC: <b>SBIN0000554</b>; Branch: <b>SBI – Bhachau</b></div>
-        <section class="sec">
-          <h3>Remittance Details</h3>
-          <div class="kv"><div class="label">Payee</div><div class="value">Paschim Gujarat Vij Company Ltd</div><div class="unit"></div></div>
-          <div class="kv"><div class="label">Bank A/C No.</div><div class="value">31729314272</div><div class="unit"></div></div>
-          <div class="kv"><div class="label">IFSC</div><div class="value">SBIN0000554</div><div class="unit"></div></div>
-          <div class="kv"><div class="label">Branch</div><div class="value">SBI – Bhachau</div><div class="unit"></div></div>
-        </section>
         <section class="sec mapping" role="table" aria-label="Amount Mapping (per formula)">
           <h3>Amount Mapping (per formula)</h3>
           <div class="footer-note" style="margin:0 0 6px 0;">
@@ -1311,10 +1304,10 @@
 @page{size:A4;margin:14mm}
 body{margin:0;font:14px system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#111}
 .sheet{width:210mm;min-height:297mm;padding:16mm 18mm 22mm;position:relative}
-.doc-header{display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:8mm}
+.doc-header{display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:4mm}
 .doc-header h2{margin:2mm 0 0;font-size:18pt}
 .doc-meta{color:#555;font-size:10.5pt;text-align:right}
-.info-bar{background:#f3f4f6;border:1px solid #e5e7eb;padding:2mm 4mm;margin-bottom:8mm;font-size:10.5pt;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.info-bar{background:#f3f4f6;border:1px solid #e5e7eb;padding:2mm 4mm;margin-bottom:8mm;font-size:10.5pt;white-space:normal;overflow:visible;text-overflow:clip;overflow-wrap:anywhere;word-break:break-word}
 @media print{.info-bar{overflow:visible;text-overflow:clip}}
 .sec{break-inside:avoid;margin:7mm 0 0}
  .sec h3{margin:0 0 3mm;font-size:12pt;border-bottom:1px solid #ddd;padding-bottom:2.5mm}

--- a/test/info-bar-a11y.spec.js
+++ b/test/info-bar-a11y.spec.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+test('info bar exposes full text via title and aria-label', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', '1.4.1 GUI Entry.html'), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'https://example.org' });
+  const el = dom.window.buildIomStatementHtml({ FINAL: 0 }, 'Jan', '2025-01-01');
+  const bar = el.querySelector('.info-bar');
+  assert.ok(bar, 'info-bar must exist');
+  const title = (bar.getAttribute('title') || '').trim();
+  const aria = (bar.getAttribute('aria-label') || '').trim();
+  assert.ok(title.length > 0, 'info-bar requires a non-empty title attribute');
+  assert.ok(aria.length > 0, 'info-bar requires a non-empty aria-label attribute');
+});
+

--- a/test/info-bar-order.spec.js
+++ b/test/info-bar-order.spec.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+test('info bar appears before the mapping section', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', '1.4.1 GUI Entry.html'), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'https://example.org' });
+  const sheet = dom.window.buildIomStatementHtml({ FINAL: 0 }, 'Jan', '2025-01-01');
+  const bar = sheet.querySelector('.info-bar');
+  const mapping = sheet.querySelector('.sec.mapping');
+  assert.ok(bar, 'info-bar must exist');
+  assert.ok(mapping, 'mapping section must exist');
+  const kids = Array.from(sheet.children);
+  const iBar = kids.indexOf(bar);
+  const iMap = kids.indexOf(mapping);
+  assert.ok(iBar > -1 && iMap > -1 && iBar < iMap, 'info-bar must precede the mapping section');
+});

--- a/test/no-remittance-table.spec.js
+++ b/test/no-remittance-table.spec.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+test('remittance table is removed; info bar remains', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', '1.4.1 GUI Entry.html'), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'https://example.org' });
+  const el = dom.window.buildIomStatementHtml({ FINAL: 0 }, 'Jan', '2025-01-01');
+  // Table and header absent
+  assert.ok(
+    !Array.from(el.querySelectorAll('h3')).some(h => /^\s*Remittance Details\s*$/i.test(h.textContent)),
+    'Remittance Details header must be removed'
+  );
+  const clone = el.cloneNode(true);
+  clone.querySelector('.info-bar')?.remove();
+  assert.ok(
+    !/Payee|Bank A\/C No\.|IFSC|Branch/.test(clone.textContent),
+    'Remittance rows must be removed'
+  );
+  // Info bar still present
+  const bar = el.querySelector('.info-bar');
+  assert.ok(bar && /Please pay to/i.test(bar.textContent), 'info-bar should remain');
+});

--- a/test/static-title.spec.js
+++ b/test/static-title.spec.js
@@ -10,10 +10,14 @@ test('static head title and fallback info-bar rule are present', () => {
     /<title>\s*IOM\s*-\s*HT\s*Bill\s*Calculator\s*<\/title>/i.test(src),
     'Static <title> must be "IOM - HT Bill Calculator"'
   );
-  // Fallback CSS must include .info-bar styling (single line + ellipsis)
+  // Fallback CSS must allow wrapping (no truncation) and intra-token breaking
   assert.ok(
-    /\.info-bar\{[^}]*white-space:nowrap;[^}]*text-overflow:ellipsis/si.test(src),
-    'Fallback CSS must style .info-bar for nowrap + ellipsis'
+    /\.info-bar\{[^}]*white-space:\s*normal;[^}]*overflow:\s*visible;[^}]*text-overflow:\s*clip/si.test(src),
+    'Fallback CSS must style .info-bar for wrapping'
+  );
+  assert.ok(
+    /\.info-bar\{[^}]*overflow-wrap:\s*anywhere/si.test(src) || /\.info-bar\{[^}]*word-break:\s*break-word/si.test(src),
+    'Fallback CSS must enable intra-token wrapping (overflow-wrap:anywhere or word-break:break-word)'
   );
   // Fallback CSS must style the document title using the current selector
   assert.ok(
@@ -33,11 +37,18 @@ test('static head title and fallback info-bar rule are present', () => {
   // Export HTML template must explicitly set color-scheme meta to light
   assert.ok(/<meta\s+name=["']color-scheme["']\s+content=["']light["']\s*>/i.test(src), 'Export HTML must set color-scheme=light');
 
-  // Primary print CSS (#print-css) should also enforce nowrap + ellipsis on .info-bar
+  // Primary print CSS must allow wrapping and intra-token breaking
   assert.ok(
-    /\.info-bar\s*\{[^}]*white-space:\s*nowrap;[^}]*text-overflow:\s*ellipsis/si.test(cssBlock),
-    'Primary #print-css must style .info-bar for nowrap + ellipsis'
+    /\.info-bar\s*\{[^}]*white-space:\s*normal;[^}]*overflow:\s*visible;[^}]*text-overflow:\s*clip/si.test(cssBlock),
+    'Primary #print-css must style .info-bar for wrapping'
   );
+  assert.ok(
+    /\.info-bar[^}]*overflow-wrap:\s*anywhere/si.test(cssBlock) || /\.info-bar[^}]*word-break:\s*break-word/si.test(cssBlock),
+    'Primary #print-css must enable intra-token wrapping (overflow-wrap:anywhere or word-break:break-word)'
+  );
+  // Guard against regressions to truncation
+  assert.ok(!/\.info-bar[^}]*white-space:\s*nowrap/si.test(cssBlock), 'No nowrap on .info-bar');
+  assert.ok(!/\.info-bar[^}]*text-overflow:\s*ellipsis/si.test(cssBlock), 'No ellipsis on .info-bar');
 
   // Fallback export window must set its own title correctly
   assert.ok(


### PR DESCRIPTION
## Summary
- allow the gray remittance info bar to wrap naturally instead of truncating
- drop redundant "Remittance Details" table from the sheet and tests
- expand test coverage for info bar wrapping, intra-token breaking, absence of remittance table, and ordering before the mapping section
- align fallback print header spacing with primary and guard info-bar title/aria-label attributes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ce1383288333b1f13de2e0c8bbf6