### PR TITLE
Add INR words helper and integrate with SAP long text

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -1126,13 +1126,38 @@
         }catch{ return label; }
       }
 
+      function inWords(value){
+        const a = ['', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine', 'Ten', 'Eleven', 'Twelve', 'Thirteen', 'Fourteen', 'Fifteen', 'Sixteen', 'Seventeen', 'Eighteen', 'Nineteen'];
+        const b = ['', '', 'Twenty', 'Thirty', 'Forty', 'Fifty', 'Sixty', 'Seventy', 'Eighty', 'Ninety'];
+        const num = Math.round(Number(value) || 0);
+        if(num === 0) return 'Zero';
+        const toWords = n => {
+          if(n < 20) return a[n];
+          const tens = Math.floor(n / 10);
+          const ones = n % 10;
+          return [b[tens], a[ones]].filter(Boolean).join(' ');
+        };
+        const parts = [];
+        const crore = Math.floor(num / 1e7);
+        const lakh = Math.floor(num / 1e5) % 100;
+        const thousand = Math.floor(num / 1000) % 100;
+        const hundred = Math.floor(num / 100) % 10;
+        const rest = num % 100;
+        if(crore) parts.push(toWords(crore) + ' Crore');
+        if(lakh) parts.push(toWords(lakh) + ' Lakh');
+        if(thousand) parts.push(toWords(thousand) + ' Thousand');
+        if(hundred) parts.push(toWords(hundred) + ' Hundred');
+        if(rest) parts.push(toWords(rest));
+        return parts.join(' ').trim();
+      }
+
       function buildSapLongText(model, billMonth){
         const prev = prevMonthLabel(billMonth);
         const amt = v => `${INR.format(Number(v || 0))}/-.`;
         const totalCreditAdj = Number(model.F16 || 0) + Number(model.G16 || 0);
         const totalDebit = Number(model.D24 || 0) + Number(model.E24 || 0) + Number(model.F24 || 0) + Number(model.F9 || 0);
         const balPrev = Number(model.E9 || 0) - Number(model.D9 || 0);
-        return [
+        const lines = [
           'Long Text for SAP:',
           `Bill Certification for ${billMonth} as given below: -`,
           `1. Current Month Bill for ${billMonth}: ${amt(model.C9)}`,
@@ -1153,9 +1178,11 @@
           `   Total Debit: ${amt(totalDebit)}`,
           `6. Balance pending credit of Previous Month (if any) (=Freeze Amount – Out Standing Arrear): ${amt(balPrev)}`,
           `7. Final Bill (=Current Month Bill + Debit Adjustment - Credit Adjustment - Balance pending credit of Previous Month): ${amt(model.FINAL)}`,
-          '',
-          `Rupees ${INR.format(Number(model.FINAL || 0)).replace(/^[₹\s\u00A0]+/,'')} Only`
-        ].join('\n');
+          ''
+        ];
+        const finalAmt = Number(model.FINAL || 0);
+        lines.push(`Rupees ${inWords(finalAmt)} Only`);
+        return lines.join('\n');
       }
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/test/inwords.spec.js
+++ b/test/inwords.spec.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+function loadDom(){
+  const html = fs.readFileSync(path.join(__dirname, '..', '1.4.1 GUI Entry.html'), 'utf8');
+  return new JSDOM(html, { runScripts: 'dangerously', url: 'https://example.org' });
+}
+
+test('inWords converts numbers to Indian currency words', () => {
+  const dom = loadDom();
+  const { inWords } = dom.window;
+  assert.equal(inWords(0), 'Zero');
+  assert.equal(inWords(1), 'One');
+  assert.equal(inWords(15), 'Fifteen');
+  assert.equal(inWords(105), 'One Hundred Five');
+  assert.equal(inWords(12345678), 'One Crore Twenty Three Lakh Forty Five Thousand Six Hundred Seventy Eight');
+  assert.equal(inWords(1.5), 'Two');
+});
+
+test('buildSapLongText uses inWords for final amount', () => {
+  const dom = loadDom();
+  const { buildSapLongText } = dom.window;
+  const model = {F16:0,G16:0,D24:0,E24:0,F24:0,F9:0,E9:0,D9:0,A24:0,B24:0,C24:0,A26:0,C9:0,FINAL:123.4};
+  const txt = buildSapLongText(model, '2025-05');
+  const lastLine = txt.trim().split('\n').pop();
+  assert.equal(lastLine, 'Rupees One Hundred Twenty Three Only');
+});


### PR DESCRIPTION
## Summary
- convert INR amounts to words via new `inWords` helper
- use word conversion in `buildSapLongText`
- add unit tests for converter and SAP long text integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a30a07495c833387eaa9b5a847c2a5