### PR TITLE
feat: add scrollable sheet list

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -126,11 +126,19 @@
 
     .pill{display:inline-flex;align-items:center;gap:8px;padding:4px 6px;border-radius:999px;
       background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.08);font-size:11px;
-      min-height:34px}
+      min-height:34px;flex:0 0 auto}
     /* keep pill text on one line, truncate gracefully */
     .pill > span{white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:100%;}
     .pill button{padding:2px 6px}
-    .pills{display:flex;gap:6px;flex-wrap:wrap}
+    .pills{
+      display:flex;
+      gap:6px;
+      overflow-x:auto;
+      overflow-y:hidden;
+      white-space:nowrap;
+      flex-wrap:nowrap;
+      max-width:100%;
+    }
     .right{float:right}
 
     /* Normalize header form-control height to match 34px tap target */
@@ -278,7 +286,7 @@
       <div class="toolbar">
         <!-- Month -->
         <label class="pill"><span>Billing Month</span><input type="month" id="billMonth"/></label>
-        <div id="sheetList" class="pills"></div>
+        <div id="sheetList" class="pills" role="listbox"></div>
 
         <!-- Workbook group -->
         <div class="group" aria-label="Workbook">
@@ -1270,7 +1278,7 @@
         btnDel.textContent = '×';
         btnDel.addEventListener('click', async (e) => {
           e.stopPropagation();
-          if(!(await confirmModal(`Remove sheet "${name}" from the workbook?`))) return;
+          if(!(await confirmModal(`Remove sheet \"${name}\" from the workbook?`))) return;
           const wb = getWB(); if(!wb) return;
           delete wb.Sheets[name];
           wb.SheetNames = wb.SheetNames.filter(n => n !== name);
@@ -1282,6 +1290,7 @@
         pill.append(btnGo, btnDel);
         list.appendChild(pill);
       });
+      list.scrollLeft = list.scrollWidth;
       persistDebounced();
     }
 


### PR DESCRIPTION
## Summary
- make sheet list horizontally scrollable and maintain constant header height
- auto-scroll to newest sheet and ensure list persists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a405ad0e888333befd6e997be6afb8