### PR TITLE
Scope INR mask outside Central Dak Receipt card

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -1507,7 +1507,7 @@
             const el = $(id);
             if(el){
               el.value = val;
-              if(el.type==='text') parseInrInput(el);
+              if(el.type==='text' && !el.closest('#receiptCard')) parseInrInput(el);
             }
           });
         }
@@ -1801,7 +1801,7 @@
         Object.entries(SAMPLE).forEach(([id,val])=>{
           const el = $(id);
           el.value = val;
-          if(el.type==='text') parseInrInput(el);
+          if(el.type==='text' && !el.closest('#receiptCard')) parseInrInput(el);
         });
       }
 
@@ -2055,7 +2055,9 @@
 
       document.addEventListener('DOMContentLoaded', () => {
       initRatesManager();
+      // Apply INR masking ONLY outside the Central Dak Receipt card
       document.querySelectorAll('input[type="text"]').forEach(el=>{
+        if (el.closest('#receiptCard')) return;   // do not mask receipt card inputs
         el.addEventListener('input', ()=>{ parseInrInput(el); compute(); });
         el.addEventListener('blur', ()=>parseInrInput(el));
       });


### PR DESCRIPTION
## Summary
- avoid applying INR formatting to inputs within Central Dak Receipt card
- skip formatting in restore and sample data routines for receipt inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a450b7e6d48333901b80093f128411