### PR TITLE
Derive SES quantities from HT bill inputs

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -850,6 +850,7 @@
       return parseFloat(el.dataset.value || el.value || 0) || 0;
     };
     const roundUp0 = x => Math.ceil(x);
+    const round2 = x => Math.round(x * 100) / 100;
 
     // Final reconciliation tolerance (INR); hoisted for clarity & micro-perf.
     // Stability guard: do not change without approval.
@@ -874,7 +875,7 @@
       { code:'WIND_ENERGY_CREDIT', name:'Wind Energy Credit' }
     ];
     const SERVICE_HINTS = {
-      EC_SLAB1: 'Hint: from “Energy Charges” (HT Bill → C4)',
+      EC_SLAB1: 'KWh billed.',
       TOD_PEAK: 'Hint: from “TOU” (HT Bill → H4)',
       TOD_NIGHT_REBATE: 'Hint: from “EHV Rebate” (HT Bill → G4)',
       PF_CHARGE_SLAB1: 'Hint: Enter Power Factor (e.g., 0.997)',
@@ -882,7 +883,7 @@
     };
     const QTY_PLACEHOLDERS = {
       PF_CHARGE_SLAB1: 'Enter Power Factor (e.g., 0.997)',
-      EC_SLAB1: 'kWh billed',
+      EC_SLAB1: 'KWh billed.',
       TOD_PEAK: 'kWh @ TOU (peak)',
       TOD_NIGHT_REBATE: 'kWh (night rebate)',
       ARREAR_ED: 'Consumption Charges (₹)'
@@ -898,7 +899,7 @@
       EC_SLAB1:4.2,
       FCA:2.45,
       TOD_PEAK:0.85,
-      TOD_NIGHT_REBATE:0.015,
+      TOD_NIGHT_REBATE:1.5,
       PF_CHARGE_SLAB1:0.0235,
       ARREAR_FCA:1,
       ARREAR_ED:0.2,
@@ -1072,28 +1073,40 @@
         const dEl=$('d_'+s.code);
         const fEl=$('f_'+s.code);
         const gEl=$('g_'+s.code);
-        let B=parseFloat(qtyEl?.value)||0;
         const C=parseFloat(tarEl?.value)||0;
         const E=parseFloat(poEl?.value)||0;
+        let B=parseFloat(qtyEl?.value)||0;
+        switch(s.code){
+          case 'MD_SLAB1':
+          case 'MD_SLAB2':
+            B=500; break;
+          case 'MD_SLAB3':{
+            const demand=num('B4');
+            const t1=parseFloat($('tar_MD_SLAB1')?.value)||0;
+            const t2=parseFloat($('tar_MD_SLAB2')?.value)||0;
+            B=(demand - 500*t1 - 500*t2)/C; B=round2(B); break; }
+          case 'EC_SLAB1':
+            B=num('A4'); break;
+          case 'TOD_PEAK':{
+            const tou=num('H4'); B=C?round2(tou/C):0; break; }
+          case 'TOD_NIGHT_REBATE':{
+            const evh = num('G4'); // EHV Rebate (₹)
+            B = C ? round2((-evh)/C) : 0; break; }
+          case 'ARREAR_ED':{
+            const tot=num('B4')+num('C4')+num('D4')+num('E4')-num('F4')-num('G4')+num('H4')+num('I4');
+            B=round2(tot); break; }
+          case 'FCA':
+            B=parseFloat($('qty_EC_SLAB1')?.value)||0; break;
+        }
+        if(qtyEl) qtyEl.value = Number.isInteger(B) ? B : B.toFixed(2);
         let D=0,F=0,G=0;
-        if(s.code==='FCA'){
-          B=parseFloat($('qty_EC_SLAB1')?.value)||0;
-          if(qtyEl) qtyEl.value=B;
-          D=B*C;
-          F=E?D/E:0;
-        }else if(s.code==='TOD_NIGHT_REBATE'){
-          D=-B*C;
-          F=E?D/E:0;
-        }else if(s.code==='PF_CHARGE_SLAB1'){
+        if(s.code==='PF_CHARGE_SLAB1'){
           const pf=B;
           D=-((pf-0.95)*dEnergy/2);
           F=E?D/E:0;
         }else if(s.code.startsWith('ARREAR_')){
           D=B*C;
           F=D;
-        }else if(s.code==='WIND_ENERGY_CREDIT'){
-          D=B*C;
-          F=E?D/E:0;
         }else{
           D=B*C;
           F=E?D/E:0;

--- a/test/sample-bill.spec.js
+++ b/test/sample-bill.spec.js
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {JSDOM} = require('jsdom');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('reference bill calculations', async () => {
+  let html = fs.readFileSync(path.join(__dirname, '..', '1.4.1 GUI Entry.html'), 'utf8');
+  html = html.replace(/<script src="\.\/xlsx\.full\.min\.js"><\/script>/, '');
+  const dom = new JSDOM(html, {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'https://example.org/'
+  });
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', () => resolve());
+  });
+  const doc = dom.window.document;
+  const setVal = (id, value) => {
+    const el = doc.getElementById(id);
+    el.value = String(value);
+    el.dataset.value = String(value);
+  };
+  assert.equal(Number(doc.getElementById('tar_TOD_NIGHT_REBATE').value), 1.5);
+  setVal('A4', 1483313);
+  setVal('B4', 880925);
+  setVal('C4', 6229914.60);
+  setVal('D4', 0);
+  setVal('E4', 3487713.86);
+  setVal('F4', 0);
+  setVal('G4', 93448.72);
+  setVal('H4', 418954.80);
+  setVal('I4', 0);
+  dom.window.compute();
+  const toNum = t => Number(t.replace(/[^0-9.-]/g, ''));
+  const qty = id => Number(doc.getElementById('qty_' + id).value);
+  const tar = id => Number(doc.getElementById('tar_' + id).value);
+  const amt = id => toNum(doc.getElementById('d_' + id).textContent);
+  const close = (a, b) => assert.ok(Math.abs(a - b) <= 0.01, `${a} ≉ ${b}`);
+  close(qty('MD_SLAB1'), 500);
+  close(tar('MD_SLAB1'), 150);
+  close(amt('MD_SLAB1'), 75000);
+  close(qty('MD_SLAB2'), 500);
+  close(tar('MD_SLAB2'), 260);
+  close(amt('MD_SLAB2'), 130000);
+  close(qty('MD_SLAB3'), 1423);
+  close(tar('MD_SLAB3'), 475);
+  close(amt('MD_SLAB3'), 675925);
+  close(qty('EC_SLAB1'), 1483313);
+  close(tar('EC_SLAB1'), 4.2);
+  close(amt('EC_SLAB1'), 6229914.60);
+  close(qty('TOD_PEAK'), 492888);
+  close(tar('TOD_PEAK'), 0.85);
+  close(amt('TOD_PEAK'), 418954.80);
+  close(qty('TOD_NIGHT_REBATE'), -62299.15);
+  close(tar('TOD_NIGHT_REBATE'), 1.5);
+  close(amt('TOD_NIGHT_REBATE'), -93448.72);
+  close(qty('ARREAR_ED'), 10924059.54);
+  close(tar('ARREAR_ED'), 0.2);
+  close(amt('ARREAR_ED'), 2184811.91);
+
+  // Changing D4 should not affect TOD_NIGHT_REBATE
+  setVal('D4', 5000);
+  dom.window.compute();
+  close(qty('TOD_NIGHT_REBATE'), -62299.15);
+  close(amt('TOD_NIGHT_REBATE'), -93448.72);
+  close(qty('ARREAR_ED'), 10929059.54);
+  close(amt('ARREAR_ED'), 2185811.91);
+});


### PR DESCRIPTION
## Summary
- Auto-calculate MD, energy, TOU, rebate and ED quantities from HT Bill inputs and tariffs
- Lock EC_SLAB1 hint and source to "KWh billed."
- Add regression test validating sample bill math
- Use only EHV rebate when deriving TOD_NIGHT_REBATE quantity and default its tariff to 1.50

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a612246bf883339e041b631abc62b8