### PR TITLE
Reconcile rates manager totals with current month bill

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -1121,9 +1121,20 @@
       });
       const badge=$('parityBadge');
       if(badge){
-        badge.textContent=`ΣD ${INR.format(totalD)} | ΣG ${INR.format(totalG)} | Δ ${INR.format(totalG-totalD)}`;
+        // Prefer authoritative C9 = A9 + B9; fallback to C9v if A9/B9 not present
+        const parseMoney = (t)=> Number(String(t||'').replace(/[^0-9.\-]/g,'')) || 0;
+        const a9El = $('A9v');
+        const b9El = $('B9v');
+        const haveAB = !!(a9El && b9El);
+        const c9FromAB = haveAB ? (parseMoney(a9El.textContent) + parseMoney(b9El.textContent)) : 0;
+        const c9Fallback = parseMoney($('C9v')?.textContent);
+        const c9 = haveAB ? c9FromAB : c9Fallback;
+
+        const delta=totalG-totalD;
+        const deltaC9=totalD-c9;
+        badge.textContent=`ΣD ${INR.format(totalD)} | ΣG ${INR.format(totalG)} | Δ ${INR.format(delta)} | vs C9 ${INR.format(deltaC9)}`;
         badge.classList.remove('good','bad');
-        badge.classList.add(Math.abs(totalG-totalD)<=0.05?'good':'bad');
+        badge.classList.add(Math.abs(delta)<=FINAL_CHECK_TOL && Math.abs(deltaC9)<=FINAL_CHECK_TOL ? 'good' : 'bad');
       }
     }
 

--- a/test/computeSes.test.js
+++ b/test/computeSes.test.js
@@ -23,6 +23,14 @@ test('arrear rows use G = D when PO rate not 1', async () => {
   doc.getElementById('qty_ARREAR_FCA').value = '100';
   doc.getElementById('tar_ARREAR_FCA').value = '1';
   doc.getElementById('po_ARREAR_FCA').value = '2';
+  // Neutralize unrelated MD slabs so ΣD = 100
+  doc.getElementById('tar_MD_SLAB1').value = '0';
+  doc.getElementById('tar_MD_SLAB2').value = '0';
+  doc.getElementById('B4').value = '0';
+  // Seed both A9 and B9 so C9 derives from A9+B9 = 100.00 (and override C9v to prove precedence)
+  (doc.getElementById('A9v') || doc.body.appendChild(Object.assign(doc.createElement('div'),{id:'A9v'}))).textContent = '₹80.00';
+  (doc.getElementById('B9v') || doc.body.appendChild(Object.assign(doc.createElement('div'),{id:'B9v'}))).textContent = '₹20.00';
+  (doc.getElementById('C9v') || doc.body.appendChild(Object.assign(doc.createElement('div'),{id:'C9v'}))).textContent = '₹999.00'; // should be ignored when A9/B9 exist
 
   dom.window.computeSes();
 
@@ -34,6 +42,17 @@ test('arrear rows use G = D when PO rate not 1', async () => {
   assert.equal(g, 100);
 
   const badgeText = doc.getElementById('parityBadge').textContent;
-  const delta = Number(badgeText.match(/Δ ₹([0-9.]+)/)[1]);
+  const match = badgeText.match(/Δ ([^|]+) \| vs C9 ([^|]+)/);
+  const delta = toNum(match[1]);
+  const deltaC9 = toNum(match[2]);
   assert.equal(delta, 0);
+  // C9 must be derived from A9+B9 = 100.00 → ΣD(=100) − C9(=100) = 0
+  assert.equal(deltaC9, 0);
+
+  // Now remove A9/B9 to verify fallback to C9v
+  doc.getElementById('A9v').remove(); doc.getElementById('B9v').remove();
+  dom.window.computeSes();
+  const match2 = doc.getElementById('parityBadge').textContent.match(/vs C9 ([^|]+)/);
+  const deltaC9_fallback = toNum(match2[1]); // ΣD(=100) − C9v(=999) = −899.00
+  assert.ok(Math.abs(deltaC9_fallback + 899.00) <= 0.01);
 });


### PR DESCRIPTION
## Summary
- Cross-check SES parity with current month bill in rates manager using A9+B9 with C9v fallback
- Align test fixtures so A9+B9 equals ΣD and cover C9v fallback
- Use FINAL_CHECK_TOL constant for parity badge thresholds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a61be0e47c8333aaf331e2a4c0400e