### PR TITLE
Document IOM/receipt one-page print paths and add agent guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,37 @@
-# Plant HT Bill Manual Entry
+# WEG Billing Calculator (Single-file App)
 
-This repository contains a single-page web application for manual entry and calculation of high-tension (HT) electricity bills.
-It is designed to run entirely in the browser without a server component.
+A single HTML file that computes HT bills, manages tariffs/PO rates, and exports:
+- **IOM – HT Bill**: one-page A4 PDF via **Save as PDF** or **Open PDF View**
+- **Central Dak Receipt**: lightweight receipt generator + **Save as PDF/Open PDF View**
+
+## Quick Start
+1. Open `1.4.1 GUI Entry.html` in a modern Chromium browser (Chrome/Edge).
+2. Pick **Billing Month**, enter HT Bill inputs and Wind credits/debits.
+3. Click **Make IOM ▾ → Render IOM**, then:
+   - **Save as PDF** for a one-page A4 export (no blank lead page).
+   - **Open PDF View** if you prefer an `about:blank` popup; allow popups.
+4. For **Central Dak Receipt — Inputs**, fill the fields → **Render Receipt** → **Save as PDF** (exactly one print dialog) or **Open PDF View**.
+
+> Tip: In the browser print dialog, turn **off** “Headers and footers”. **Default** margins are fine.
 
 ## Features
-- Interactive form for entering billing details
-- Real-time computation of bill totals
-- Local storage support for restoring previous sessions
-- Sample data loader for quick demonstrations
-- Import/export functionality powered by [SheetJS](https://sheetjs.com/) via `xlsx.full.min.js`
-- PDF export via browser print for generating printable bills
+- **IOM one-page scaling**: `.sheet.iom` + `html.print-iom` + `setIomPrintScaleIfNeeded()` fit to A4.
+- **Receipt print guard**: scoped `#htmlPrintHost` CSS; receipt renders as `.sheet.rcpt` with `role="document"`.
+- **No double print dialogs** for receipts: the card’s “Save as PDF” prints directly.
+- **Rates Manager**: editable tariffs/PO rates, parity badge with tolerance `FINAL_CHECK_TOL`.
+- **Excel export**: builds a month sheet via SheetJS.
+- **Offline-friendly**: prefers local `./xlsx.full.min.js`, then CDNs.
 
-## Getting Started
-1. Clone or download the repository.
-2. Run `npm install` to install dependencies (required before running tests).
-3. Open `1.4.1 GUI Entry.html` in a modern web browser.
-4. Enter billing values in the form. Totals are recalculated automatically as you type.
-5. Use toolbar buttons to load sample data, reset the form, import or export sheets, and generate printable previews. See [Using the Application](#using-the-application) for details.
-
-## Using the Application
-- **Add / Update Month Sheet** – store the current bill in an in-memory workbook.
-- **Upload Excel** – import an existing workbook.
-- **Download Excel** – export the workbook with all saved sheets.
-- **Sample Data** – populate the form with demonstration values.
-- **Reset** – clear the current form; **Clear Sheets** removes all stored sheets.
-- **Render Preview** – generate a printable view of the bill; **Save as PDF** downloads that preview as a PDF.
-
-## Repository Structure
-- `1.4.1 GUI Entry.html` - Main application interface and logic.
-- `xlsx.full.min.js` - Bundled SheetJS library used for Excel import/export.
-- `test/` - Node-based tests, currently including `basic.test.js` for sample calculations.
+## Troubleshooting
+- **Popup blocked (Open PDF View)**: allow popups for the file; the app falls back to a Blob URL with a warning.
+- **Unexpected page split**: ensure you used **Save as PDF** from within the app, not the browser’s generic print on the whole page.
+- **Missing Excel lib**: place `xlsx.full.min.js` next to the HTML or launch with `?xlsx=/path/to/xlsx.full.min.js`.
 
 ## Development Notes
-This project uses a `package.json` for dependency management and includes a `test` script to run the Node-based test suite.
-
-### Development Dependencies
-- `jsdom` – simulates a browser DOM so tests can run in Node.js without a real browser.
-
-### Testing
-Install dependencies with `npm install` and run tests with `npm test`.
+- Keep IDs stable: `#htmlPrintHost`, `#saveHtmlPdf`, `#openHtmlPdf`, `#receiptCard`, etc.
+- IOM print scope: add `iom` class to the IOM sheet; the app toggles `html.print-iom` during print.
+- Receipt CSS is injected once as `#receipt-css-v2`; the popup path de-scopes `#htmlPrintHost` selectors.
+- Avoid adding second click handlers to `#saveHtmlPdf` (prevents duplicate print dialogs).
 
 ## License
-This project is licensed under the ISC License. See [LICENSE](LICENSE).
-
-## Contributing
-Contributions are welcome! Please extend the test suite where possible and run `npm test` before submitting any changes.
+Add your project license here.

--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,46 @@
+# Engineering Assistant Guide (`agent.md`)
+
+This document defines how changes are proposed, reviewed, and accepted.
+
+## Preferred Submission Format
+Your review or follow-up must use these sections:
+- **Context**
+- **Objective**
+- **KEEP**
+- **IMPROVE #…** (each with: *Severity*, *Rationale*, a “Codex, please …” instruction, and *Acceptance criteria* checkboxes)
+- **Global checks**
+
+If details are missing, add brief **Assumptions** and proceed. Include unified diffs when proposing code changes.
+
+## Convergence & Stop Rules
+- **Definition of Done:** All Acceptance criteria pass; no P1/P2 issues remain; no regressions; performance/UX targets meet the Objective.
+- **Scope & Change Budget:** Only what’s needed to meet the Objective; no broad refactors; keep diffs minimal and localized.
+- **Stability Guards:** Preserve named invariants and public APIs (IDs, CSS classes like `.sheet.iom`, `html.print-iom`, `#receipt-css-v2`, and helpers like `setIomPrintScaleIfNeeded`). Do not change user-visible labels/strings without explicit approval.
+- **Idempotency Check:** Re-running the assistant after applying a patch should yield zero additional changes (no churn).
+- **Verification:** Provide a minimal test/quick-check plan and evidence (commands, steps, expected outputs) that demonstrate Acceptance criteria pass.
+- **Exit:** When done, state **“CONVERGED”** and list any low-value optimizations intentionally deferred.
+
+## Code & UX Expectations
+- **IOM exports** must be a **single A4 page** in both “Save as PDF” and “Open PDF View”.
+- **Receipts** must open **exactly one** print dialog on “Save as PDF”.
+- Print guards must hide app chrome and keep only the sheet visible.
+- Popup paths must handle blocked popups with a user-visible fallback.
+- Do not introduce duplicate event bindings.
+
+## Patches
+Provide diffs suitable for:
+```bash
+(cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF'
+…patch…
+EOF
+)
+```
+
+## Commit Messages
+
+Use concise, imperative subjects (≤72 chars), plus a brief body when helpful.
+
+```
+feat: document IOM/receipt one-page print paths in README
+docs: add agent.md with review rules and DoD
+```


### PR DESCRIPTION
## Summary
- refresh README to explain IOM and Central Dak Receipt PDF export paths
- codify change-management rules in agent.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a830f291248333b74f3fa8a18c1066