### PR TITLE
Widen receipt card and improve responsive layout

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -21,6 +21,7 @@
       --ring:2px solid rgba(34,211,238,.6);
       --shadow: 0 20px 50px rgba(0,0,0,.45);
       --radius: 18px;
+      --warn-outline: rgba(255,120,120,.6);
     }
     /* Force a light palette for export */
     :root { color-scheme: light only; }
@@ -327,6 +328,7 @@
     grid-template-columns: 1fr 1fr;
     gap: 8px 16px;
   }
+  #receiptCard .fields .f{ grid-column: span 1; }
   /* Hard guarantee that the card is typeable/clickable */
   #receiptCard{ position:relative; z-index:1; }
   #receiptCard, #receiptCard *{ pointer-events:auto; }
@@ -342,16 +344,27 @@
     border-radius:8px;
   }
   #receiptCard .hint{ display:block; font-size:11px; opacity:.75; margin-top:4px; }
-  #receiptCard input.warn{ outline:2px solid rgba(255,120,120,.6); }
+  #receiptCard input.warn{ outline:2px solid var(--warn-outline, rgba(255,120,120,.6)); }
   #receiptCard .row-3up{
-    display:grid; grid-template-columns: 1fr 1fr 1fr; gap:8px 12px; grid-column:1 / -1;
+    display:grid;
+    grid-template-columns: 1fr 1fr;
+    gap:8px 16px;
+    grid-column:1 / -1;
   }
   @media (max-width: 720px){
     #receiptCard .fields{ grid-template-columns: 1fr; }
     #receiptCard .row-3up{ grid-template-columns: 1fr; }
   }
+  @media (min-width: 1200px){
+    #receiptCard .fields{ grid-template-columns: 1fr 1fr 1fr; }
+    #receiptCard .row-3up{ display: contents; }
+  }
   #receiptCard .actions{
-    display:flex; gap:8px; justify-content:flex-end; margin-top:10px;
+    display:flex;
+    gap:8px;
+    justify-content:flex-end;
+    margin-top:10px;
+    flex-wrap:wrap;
   }
 </style>
 </head>
@@ -585,7 +598,7 @@
         <div class="muted" style="margin-top:4px;">Click Generate, review, then Copy and paste into SAP.</div>
       </section>
         <!-- Central Dak Receipt Inputs -->
-        <section class="card span-4" id="receiptCard">
+        <section class="card span-8" id="receiptCard">
           <h2>Central Dak Receipt — Inputs</h2>
           <div class="fields">
             <!-- Row 1 -->

--- a/test/warn-outline.spec.js
+++ b/test/warn-outline.spec.js
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const {JSDOM} = require('jsdom');
+
+test('warn outline token exists and uses semi-transparent color', async () => {
+  let html = fs.readFileSync(path.join(__dirname, '..', '1.4.1 GUI Entry.html'), 'utf8');
+  html = html.replace(/<script src="\.\/xlsx\.full\.min\.js"><\/script>/, '');
+
+  const dom = new JSDOM(html, {runScripts: 'dangerously', resources: 'usable', url: 'https://example.org/'});
+
+  await new Promise((resolve) => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.addEventListener('load', () => resolve());
+  });
+
+  const rootStyle = dom.window.getComputedStyle(dom.window.document.documentElement);
+  const token = rootStyle.getPropertyValue('--warn-outline').trim();
+  assert.ok(token, '--warn-outline token missing on :root');
+
+  const m = token.match(/rgba\([^,]+,[^,]+,[^,]+,\s*([0-9.]+)\)/);
+  assert.ok(m, '--warn-outline should be rgba');
+  assert.ok(parseFloat(m[1]) < 1, '--warn-outline alpha should be < 1');
+
+  const input = dom.window.document.querySelector('#receiptCard input');
+  input.classList.add('warn');
+  const outline = dom.window.getComputedStyle(input).getPropertyValue('outline');
+  assert.match(outline, /var\(--warn-outline/, '#receiptCard input.warn should use --warn-outline');
+  assert.match(
+    outline,
+    /var\(--warn-outline,\s*rgba\(255,120,120,.6\)\)/,
+    '#receiptCard input.warn should provide rgba fallback with 60% alpha'
+  );
+});


### PR DESCRIPTION
## Summary
- widen Central Dak Receipt card to span more columns on desktop
- add responsive field grid that flows receipt fields into three columns at ≥1200px and two columns at intermediate widths
- flex-align receipt actions for consistent button placement
- centralize warning outline color token in root with fallback for consistent styling
- add unit test guarding warn-outline token, alpha, and fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afb4f227e08333ab79de2c0079626b