### PR TITLE
hide footer from printed receipt

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -2853,7 +2853,7 @@
   <style id="print-guard-receipt">
   @media print{
     /* Hide chrome; keep rendered sheet visible */
-    header, .toolbar, .card:not(.sheet), #toasts, .ui { display:none !important; }
+    header, .toolbar, .card:not(.sheet), #toasts, .ui, .footer { display:none !important; }
     #htmlPrintHost { display:block !important; }
     #htmlPrintHost .sheet{ display:block !important; border:none; width:auto; min-height:auto; margin:0; padding:0 0 16mm 0; break-inside:avoid; -webkit-print-color-adjust:exact; print-color-adjust:exact }
     #htmlPrintHost .sheet:not(:last-of-type){ break-after:page; page-break-after:always }


### PR DESCRIPTION
## Summary
- suppress UI footer when printing receipts so "Pro-tips" don't appear in exported PDF

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afd39f7ed4833398dfa91def00be95