### PR TITLE
fix: avoid blank receipt pages when saving PDF

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -2522,6 +2522,10 @@
         const host = document.getElementById('htmlPrintHost');
         if (!host) { toast('Please render a preview first.', 'warn'); return; }
         if (host.getAttribute('aria-busy') === 'true') { toast('Preview is busy, please wait…', 'info'); return; }
+        // Remove empty/hidden sheets to avoid blank pages in print
+        host.querySelectorAll('.sheet').forEach(s => {
+          if (s.hidden || s.style.display === 'none' || !s.innerHTML.trim()) s.remove();
+        });
         if (!host.querySelector('.sheet')) {
           toast('Please render a preview first.', 'warn');
           return;
@@ -2941,7 +2945,7 @@
     #htmlPrintHost .sheet.rcpt .page-number,
     #htmlPrintHost .sheet.rcpt .footer-note { display:none !important; }
     /* Proper page breaks for multi-sheet prints (if any) */
-    #htmlPrintHost .sheet:not(:last-of-type){ break-after:page; page-break-after:always }
+    #htmlPrintHost .sheet:not(:last-of-type):not(:empty){ break-after:page; page-break-after:always }
     @page{ size:A4; margin:14mm }
   }
   </style>


### PR DESCRIPTION
## Summary
- remove empty or hidden sheets before invoking `window.print`
- ignore empty sheets in receipt print CSS

## Testing
- `npm test`
- `node - <<'NODE'
const { JSDOM } = require('jsdom');
const dom = new JSDOM(`<div id="htmlPrintHost"><section class="sheet rcpt"><p>ok</p></section><section class="sheet"></section></div><button id="saveHtmlPdf"></button>`);
const { window } = dom;
const { document } = window;
function toast(){}
function setDisabled(){}
function setBusy(){}
function onPrintLifecycle(){}
function setIomPrintScaleIfNeeded(){}
window.print = () => {
  console.log('sheets at print time:', document.querySelectorAll('#htmlPrintHost .sheet').length);
};
const btnSave = document.getElementById('saveHtmlPdf');
btnSave.addEventListener('click', () => {
  const host = document.getElementById('htmlPrintHost');
  if (!host) { toast('Please render a preview first.', 'warn'); return; }
  if (host.getAttribute('aria-busy') === 'true') { toast('Preview is busy, please wait…', 'info'); return; }
  host.querySelectorAll('.sheet').forEach(s => {
    if (s.hidden || s.style.display === 'none' || !s.innerHTML.trim()) s.remove();
  });
  if (!host.querySelector('.sheet')) {
    toast('Please render a preview first.', 'warn');
    return;
  }
  setDisabled(btnSave, true);
  setBusy(host, true);
  onPrintLifecycle({host, reenable: ()=>{}});
  try {
    document.documentElement.classList.add('print-iom');
    const sheet = host.querySelector('.sheet.iom') || host.querySelector('.sheet');
    if (sheet && typeof setIomPrintScaleIfNeeded === 'function') {
      setIomPrintScaleIfNeeded(sheet);
    }
    window.addEventListener('afterprint', () => {
      document.documentElement.classList.remove('print-iom');
    }, { once: true });
  } catch(_) {}
  window.print();
});
btnSave.click();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b016d093748333b75ea22e6a19d293