### PR TITLE
fix: prune hidden receipt sheets before printing

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -834,10 +834,10 @@
           await withBusy('saveReceiptPdfInCard', async () => {
             ensureReceiptRenderedThen(() => {
               const host  = document.getElementById('htmlPrintHost');
+              document.documentElement.classList.add('print-rcpt');
               prunePrintSheets(host);
               const sheet = host && (host.querySelector('.sheet.receipt') || host.querySelector('.sheet.rcpt'));
               if (sheet){
-                document.documentElement.classList.add('print-rcpt');
                 const doFit = () => {
                   try {
                   if (typeof window.setRcptPrintScaleIfNeeded === 'function') window.setRcptPrintScaleIfNeeded(sheet);
@@ -895,7 +895,8 @@
       function prunePrintSheets(host){
         if (!host) return;
         host.querySelectorAll('.sheet').forEach(s => {
-          if (s.hidden || s.style.display === 'none' || !s.innerHTML.trim()) s.remove();
+          const cs = getComputedStyle(s);
+          if (s.hidden || cs.display === 'none' || cs.visibility === 'hidden' || !s.innerHTML.trim()) s.remove();
         });
       }
 


### PR DESCRIPTION
## Summary
- drop receipt sheets hidden by CSS
- prune sheets before Save PDF prints

## Testing
- `npm test`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b01efe91508333951dabda0f178d03