### PR TITLE
fix: prune print host to single receipt sheet

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -835,7 +835,7 @@
             ensureReceiptRenderedThen(() => {
               const host  = document.getElementById('htmlPrintHost');
               document.documentElement.classList.add('print-rcpt');
-              prunePrintSheets(host);
+              (window.prunePrintSheets || prunePrintSheets)(host);
               const sheet = host && (host.querySelector('.sheet.receipt') || host.querySelector('.sheet.rcpt'));
               if (sheet){
                 const doFit = () => {
@@ -894,10 +894,19 @@
 
       function prunePrintSheets(host){
         if (!host) return;
-        host.querySelectorAll('.sheet').forEach(s => {
+        // 1) Remove any sheet that is hidden, not displayed, or empty
+        const all = Array.from(host.querySelectorAll('.sheet'));
+        all.forEach(s => {
           const cs = getComputedStyle(s);
           if (s.hidden || cs.display === 'none' || cs.visibility === 'hidden' || !s.innerHTML.trim()) s.remove();
         });
+
+        // 2) Ensure only one relevant sheet remains before printing
+        const viable = Array.from(host.querySelectorAll('.sheet'));
+        if (viable.length <= 1) return;
+        const lastTagged = [...host.querySelectorAll('.sheet.receipt, .sheet.rcpt')].pop()
+          || viable[viable.length - 1];
+        viable.forEach(s => { if (s !== lastTagged) s.remove(); });
       }
 
       const esc = (s) => String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])).replace(/'/g,'&#39;');
@@ -2952,12 +2961,12 @@
     #htmlPrintHost .sheet.rcpt .page-number,
     #htmlPrintHost .sheet.rcpt .footer-note { display:none !important; }
     /* Proper page breaks for multi-sheet prints (if any) */
-    #htmlPrintHost .sheet:not(:last-of-type):not(:empty){ break-after:page; page-break-after:always }
+    #htmlPrintHost > .sheet:not(:last-child):not(:empty){ break-after:page; page-break-after:always }
     @page{ size:A4; margin:14mm }
   }
   </style>
   <script>
-    // Fit receipt to a single A4 page with a tiny scale only if needed (≤ 2%)
+    // Fit receipt to a single A4 page with a modest scale only if needed (≤ 10%)
     if (typeof window.setRcptPrintScaleIfNeeded !== 'function') {
       window.setRcptPrintScaleIfNeeded = function(sheet){
         try{
@@ -2975,12 +2984,28 @@
           const pagePx = mmToPx(297 - 14*2); // account for @page margin 14mm top/bottom
           const h = sheet.getBoundingClientRect().height || 0;
           if (h > pagePx){
-            const scale = Math.max(0.98, Math.min(1, pagePx / h));
+            const scale = Math.max(0.90, Math.min(1, pagePx / h));
             document.documentElement.style.setProperty('--rcpt-scale', String(scale));
           }
         }catch(_){ }
       };
     }
+    // Do not override the earlier (enhanced) implementation.
+    window.prunePrintSheets = window.prunePrintSheets || function prunePrintSheets(host){
+      if (!host) return;
+      // 1) Remove hidden/empty sheets
+      const all = Array.from(host.querySelectorAll('.sheet'));
+      all.forEach(s => {
+        const cs = getComputedStyle(s);
+        if (s.hidden || cs.display === 'none' || cs.visibility === 'hidden' || !s.innerHTML.trim()) s.remove();
+      });
+      // 2) Keep only one relevant sheet
+      const viable = Array.from(host.querySelectorAll('.sheet'));
+      if (viable.length <= 1) return;
+      const lastTagged = [...host.querySelectorAll('.sheet.receipt, .sheet.rcpt')].pop()
+        || viable[viable.length - 1];
+      viable.forEach(s => { if (s !== lastTagged) s.remove(); });
+    };
   </script>
   <style>
     /* Apply tiny scale only when printing receipt */


### PR DESCRIPTION
## Context
Central Dak receipts produced extra blank pages because stale or oversized sheets were left in `#htmlPrintHost` before printing.

## Objective
Ensure the receipt export path prints exactly one page without affecting IOM flows.

## Changes
- call the window-scoped `prunePrintSheets` before printing receipts
- allow up to 10% receipt scaling and tighten page-break selector to ignore non-sheet children

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b015fd419883338ed1203fd2e1ba22