### PR TITLE
fix: normalize receipt pruning and guard blank pages

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -835,7 +835,7 @@
             ensureReceiptRenderedThen(() => {
               const host  = document.getElementById('htmlPrintHost');
               document.documentElement.classList.add('print-rcpt');
-              (window.prunePrintSheets || prunePrintSheets)(host);
+              prunePrintSheets(host);
               const sheet = host && (host.querySelector('.sheet.receipt') || host.querySelector('.sheet.rcpt'));
               if (sheet){
                 const doFit = () => {
@@ -2961,7 +2961,7 @@
     #htmlPrintHost .sheet.rcpt .page-number,
     #htmlPrintHost .sheet.rcpt .footer-note { display:none !important; }
     /* Proper page breaks for multi-sheet prints (if any) */
-    #htmlPrintHost > .sheet:not(:last-child):not(:empty){ break-after:page; page-break-after:always }
+    #htmlPrintHost > .sheet:not(:only-child):not(:last-child):not(:empty){ break-after:page; page-break-after:always }
     @page{ size:A4; margin:14mm }
   }
   </style>
@@ -2992,19 +2992,31 @@
     }
     // Do not override the earlier (enhanced) implementation.
     window.prunePrintSheets = window.prunePrintSheets || function prunePrintSheets(host){
-      if (!host) return;
-      // 1) Remove hidden/empty sheets
-      const all = Array.from(host.querySelectorAll('.sheet'));
-      all.forEach(s => {
-        const cs = getComputedStyle(s);
-        if (s.hidden || cs.display === 'none' || cs.visibility === 'hidden' || !s.innerHTML.trim()) s.remove();
-      });
-      // 2) Keep only one relevant sheet
-      const viable = Array.from(host.querySelectorAll('.sheet'));
-      if (viable.length <= 1) return;
-      const lastTagged = [...host.querySelectorAll('.sheet.receipt, .sheet.rcpt')].pop()
-        || viable[viable.length - 1];
-      viable.forEach(s => { if (s !== lastTagged) s.remove(); });
+      try{
+        if (!host) return;
+        // Remove hidden/empty sheets first (use computed styles for robustness)
+        const allSheets = [...host.querySelectorAll('.sheet')];
+        allSheets.forEach(s => {
+          const cs = getComputedStyle(s);
+          const isEmpty = s.matches(':empty');
+          const isHidden = s.hidden || cs.display === 'none' || cs.visibility === 'hidden';
+          if (isEmpty || isHidden) s.remove();
+        });
+
+        // Fast-path: if exactly one non-empty sheet remains, nothing to do
+        {
+          const remaining = [...host.querySelectorAll('.sheet')].filter(s => !s.matches(':empty'));
+          if (remaining.length === 1){
+            return;
+          }
+        }
+
+        const sheets = [...host.querySelectorAll('.sheet')];
+        // Prefer a tagged receipt sheet if present; otherwise keep the last sheet
+        const lastTagged = [...host.querySelectorAll('.sheet.receipt, .sheet.rcpt')].pop();
+        const keep = lastTagged || sheets[sheets.length - 1];
+        sheets.forEach(s => { if (s !== keep) s.remove(); });
+      }catch(_){ }
     };
   </script>
   <style>


### PR DESCRIPTION
## Summary
- call prunePrintSheets directly in receipt Save as PDF path
- prevent blank trailing pages by ignoring empty or single sheets
- ensure fallback prunePrintSheets removes hidden/empty nodes and keeps only one sheet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0422e0d388333a51ecc0f83004ac6