### PR TITLE
fix: sync receipt print guard with dynamic CSS

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -2946,11 +2946,12 @@
   <style id="print-guard-receipt">
   @media print{
     /* Hide chrome; keep rendered sheet visible */
-    header, .toolbar, .card:not(.sheet), #toasts, .ui, .footer { display:none !important; }
+    header, .toolbar, .card:not(.sheet), #toasts, .ui { display:none !important; }
     #htmlPrintHost { display:block !important; }
     /* Base sheet rules for print host (neutral) */
     #htmlPrintHost .sheet{
-      display:block !important; border:none; width:auto; margin:0;
+      display:block !important; border:none; width:auto; min-height:auto; margin:0;
+      padding:0 0 16mm 0; break-inside:avoid;
       -webkit-print-color-adjust:exact; print-color-adjust:exact;
     }
     /* RECEIPT-ONLY tightening to prevent fractional overflow */


### PR DESCRIPTION
## Summary
- ensure receipt print guard selector and declarations match dynamic CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b16e67c4648333a4714ee9e022ea40