### PR TITLE
fix: remove Central Dak Receipt footer from PDF preview

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -121,7 +121,6 @@
     .bad{color:var(--bad)}
     .warn{color:var(--warn)}
 
-    .footer{margin-top:18px;color:var(--muted);font-size:12px}
     .muted{color:var(--muted)}
     .hr{height:1px;background:linear-gradient(90deg, rgba(255,255,255,.15), rgba(255,255,255,.03));margin:14px 0}
 
@@ -639,7 +638,6 @@
         </section>
     </div>
 
-  <div class="footer">Pro‑tips: enter positive numbers for all rebates/credits (the app handles signs). Rounding of kWh shares matches <span class="mono">ROUNDUP(…,0)</span>. Values are live‑calculated; add a month sheet when ready.</div>
   </div>
 
   <div id="htmlPrintHost" role="region" aria-label="A4 print preview" aria-busy="false" tabindex="-1"></div>


### PR DESCRIPTION
## Summary
- remove tip footer from Central Dak Receipt markup so PDFs stay clean

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1762522f0833382f5e8d08bf2dc11