### PR TITLE
fix: prune hidden and redundant print sheets

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -892,27 +892,29 @@
 
       function prunePrintSheets(host){
         if (!host) return;
-        const sheets = Array.from(host.querySelectorAll('.sheet'));
-        sheets.forEach(s => {
-          try{
-            const cs = window.getComputedStyle(s);
-            const hidden = s.hasAttribute('hidden') ||
-                          cs.display === 'none' ||
-                          cs.visibility === 'hidden' ||
-                          !s.offsetHeight;
-            const empty = !s.textContent.trim();
-            if (hidden || empty) s.remove();
-          }catch{}
-        });
-        const remaining = Array.from(host.querySelectorAll('.sheet'));
-        if (remaining.length <= 1) return;
-        let keep = null;
-        for (let i = remaining.length - 1; i >= 0; i--){
-          const el = remaining[i];
-          if (el.classList.contains('receipt') || el.classList.contains('rcpt')){ keep = el; break; }
+        for (const el of Array.from(host.querySelectorAll('.sheet'))){
+          const cs = window.getComputedStyle(el);
+          const hidden = el.hasAttribute('hidden') ||
+                        cs.display === 'none' ||
+                        cs.visibility === 'hidden' ||
+                        !el.offsetHeight;
+          const empty = !el.textContent.trim();
+          if (hidden || empty) el.remove();
         }
-        keep = keep || remaining[remaining.length-1];
-        remaining.forEach(el => { if (el !== keep) el.remove(); });
+        const sheets = Array.from(host.querySelectorAll('.sheet'));
+        if (sheets.length <= 1) return;
+        let keep = null;
+        for (let i = sheets.length - 1; i >= 0; i--){
+          const el = sheets[i];
+          if (el.classList.contains('receipt') || el.classList.contains('rcpt')){
+            keep = el;
+            break;
+          }
+        }
+        keep = keep || sheets[sheets.length - 1];
+        for (const el of sheets){
+          if (el !== keep) el.remove();
+        }
       }
       window.prunePrintSheets = prunePrintSheets;
 


### PR DESCRIPTION
## Summary
- remove hidden or empty sheets before printing
- keep only the last receipt/rcpt sheet (or final sheet) when multiple exist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1988567608333915cfc2dcaa2c915