### PR TITLE
fix: prune hidden print sheets

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -892,7 +892,8 @@
 
       function prunePrintSheets(host){
         if (!host) return;
-        for (const el of Array.from(host.querySelectorAll('.sheet'))){
+        const sheets = Array.from(host.children).filter(el => el.classList.contains('sheet'));
+        for (const el of sheets){
           const cs = window.getComputedStyle(el);
           const hidden = el.hasAttribute('hidden') ||
                         cs.display === 'none' ||
@@ -901,18 +902,18 @@
           const empty = !el.textContent.trim();
           if (hidden || empty) el.remove();
         }
-        const sheets = Array.from(host.querySelectorAll('.sheet'));
-        if (sheets.length <= 1) return;
+        const remaining = Array.from(host.children).filter(el => el.classList.contains('sheet'));
+        if (remaining.length <= 1) return;
         let keep = null;
-        for (let i = sheets.length - 1; i >= 0; i--){
-          const el = sheets[i];
+        for (let i = remaining.length - 1; i >= 0; i--){
+          const el = remaining[i];
           if (el.classList.contains('receipt') || el.classList.contains('rcpt')){
             keep = el;
             break;
           }
         }
-        keep = keep || sheets[sheets.length - 1];
-        for (const el of sheets){
+        keep = keep || remaining[remaining.length - 1];
+        for (const el of remaining){
           if (el !== keep) el.remove();
         }
       }


### PR DESCRIPTION
## Summary
- Ensure `prunePrintSheets` filters only direct child `.sheet` elements of `#htmlPrintHost`
- Drop hidden or empty sheets and keep only the last receipt/final sheet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b19c21a5208333945ce81fb1c316bc