### PR TITLE
fix: prune receipt print sheets before PDF save

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -835,9 +835,8 @@
               document.documentElement.classList.add('print-rcpt');
               prunePrintSheets(host);
               const sheet = host && (host.querySelector('.sheet.receipt') || host.querySelector('.sheet.rcpt'));
-              if (sheet){
-                const doFit = () => {
-                  try {
+              const doFit = () => {
+                try {
                   if (typeof window.setRcptPrintScaleIfNeeded === 'function') window.setRcptPrintScaleIfNeeded(sheet);
                 } catch(_) {}
               };
@@ -850,11 +849,6 @@
                   try { window.focus(); } catch {}
                   window.print();
                 });
-            } else {
-              // Legacy fallback: still honor print if no sheet detected.
-              try { window.focus(); } catch {}
-              window.print();
-            }
             const cleanup = () => {
               document.title = prevTitle;
               document.documentElement.classList.remove('print-rcpt');


### PR DESCRIPTION
## Summary
- prune print sheets right after enabling receipt print mode
- drop legacy window-based print fallbacks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b19cf1b6d08333a8dafaa02ae2f15c