### PR TITLE
fix: prune hidden sheets before printing

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -891,8 +891,7 @@
           const cs = window.getComputedStyle(el);
           const hidden = el.hasAttribute('hidden') ||
                         cs.display === 'none' ||
-                        cs.visibility === 'hidden' ||
-                        !el.offsetHeight;
+                        cs.visibility === 'hidden';
           const empty = !el.textContent.trim();
           if (hidden || empty) el.remove();
         }


### PR DESCRIPTION
## Summary
- tighten prunePrintSheets to drop hidden or empty sheets
- retain only the last receipt sheet, or the last sheet when no receipt exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b19ea6ba7c8333b1b7dac8a5d57d19