### PR TITLE
fix: prune sheets immediately before printing receipt

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -833,7 +833,6 @@
             ensureReceiptRenderedThen(() => {
               const host  = document.getElementById('htmlPrintHost');
               document.documentElement.classList.add('print-rcpt');
-              prunePrintSheets(host);
               const sheet = host && (host.querySelector('.sheet.receipt') || host.querySelector('.sheet.rcpt'));
               const doFit = () => {
                 try {
@@ -847,6 +846,7 @@
                 .then(() => {
                   doFit();
                   try { window.focus(); } catch {}
+                  prunePrintSheets(host);
                   window.print();
                 });
             const cleanup = () => {


### PR DESCRIPTION
## Context
- Ensure receipt print uses the intended sheet and cleans up extras.

## Objective
- Prune extraneous sheets immediately before printing from the Inputs card.

## KEEP
- Single `btnSaveInCard` click binding to avoid re-entrancy.

## IMPROVE #1
- **Severity:** P3
- **Rationale:** prevent stray sheets in receipt PDF.
- **Codex, please** invoke `prunePrintSheets(host)` right before `window.print()`.
- [x] `prunePrintSheets(host)` precedes `window.print()`.
- [x] no conditional fallbacks remain.

## Global checks
- [x] `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ac7ab58483338f868bbe05c74e2d