### PR TITLE
fix: refine print sheet pruning logic

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -890,16 +890,24 @@
         const sheets = Array.from(host.children).filter(el => el.classList.contains('sheet'));
         for (const el of sheets){
           const cs = window.getComputedStyle(el);
-          const isHidden = el.hidden || cs.display === 'none' || cs.visibility === 'hidden';
-          const isEmpty = !el.textContent.trim();
-          if (isHidden || isEmpty) el.remove();
+          const hidden = el.hasAttribute('hidden') ||
+                         cs.display === 'none' ||
+                         cs.visibility === 'hidden';
+          const empty  = !el.textContent.trim();
+          if (hidden || empty) el.remove();
         }
 
         const remaining = Array.from(host.children).filter(el => el.classList.contains('sheet'));
         if (remaining.length <= 1) return;
-
-        const keep = [...remaining].reverse().find(el => el.classList.contains('receipt') || el.classList.contains('rcpt'))
-                    || remaining[remaining.length - 1];
+        let keep = null;
+        for (let i = remaining.length - 1; i >= 0; i--){
+          const el = remaining[i];
+          if (el.classList.contains('receipt') || el.classList.contains('rcpt')){
+            keep = el;
+            break;
+          }
+        }
+        keep = keep || remaining[remaining.length - 1];
         for (const el of remaining){
           if (el !== keep) el.remove();
         }


### PR DESCRIPTION
## Context
The print helper should drop hidden or empty sheets and keep only the relevant receipt sheet.

## Objective
Handle hidden elements more robustly and choose the correct sheet to retain when multiple sheets exist.

## KEEP
- Existing print helper behaviors and public APIs.

## IMPROVE #1
- **Severity:** medium
- **Rationale:** Prior receipt selection could miss hidden states and used a less explicit scan.
- **Codex, please:** update `prunePrintSheets` to ignore hidden/empty sheets based on computed styles and preserve the last receipt (or final sheet) only.
- **Acceptance criteria**
  - [x] Hidden or empty sheets are removed.
  - [x] Latest receipt/rcpt sheet is kept.
  - [x] `npm test` passes.

## Global checks
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1aef9b3748333aeb129e7cfef1714