### PR TITLE
feat: add monthly data analysis pane

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -449,6 +449,16 @@
             </div>
           </details>
         </div>
+        <!-- Analysis menu -->
+        <div class="menu" aria-label="Analysis">
+          <details>
+            <summary aria-haspopup="menu">Analysis ▾</summary>
+            <div class="menu-panel" role="menu">
+              <button id="analyzeWorkbook" role="menuitem" class="ghost">Build Monthly Trends</button>
+              <button id="exportAnalysisCsv" role="menuitem" class="ghost">Export Analysis CSV</button>
+            </div>
+          </details>
+        </div>
       </div>
       </header>
 
@@ -634,6 +644,26 @@
           <div class="actions" role="group" aria-label="Receipt actions">
             <button id="renderReceiptInCard" type="button" aria-label="Render Central Dak Receipt">Render Receipt</button>
             <button id="saveReceiptPdfInCard" type="button" class="ghost" aria-label="Save Central Dak Receipt as PDF">Save as PDF</button>
+          </div>
+        </section>
+        <!-- Data Analysis card -->
+        <section class="card span-12" id="analysisCard" hidden>
+          <h2>Data Analysis <span class="help">Trends across YYYY-MM sheets</span></h2>
+          <div id="analysisMeta" class="muted" style="margin-bottom:8px;"></div>
+          <div id="analysisChartHost" class="box" style="overflow:auto"><!-- inline SVG injected --></div>
+          <div class="hr"></div>
+          <div style="max-height:320px;overflow:auto">
+            <table id="analysisTable" style="width:100%;border-collapse:collapse;font-size:12px">
+              <thead>
+                <tr>
+                  <th style="text-align:left">Month</th>
+                  <th>A4 kWh</th><th>C9 ₹</th><th>H9 ₹</th><th>I9 ₹</th>
+                  <th>B19 ₹/kWh</th><th>A18 kWh</th><th>C18 kWh</th><th>C26 ₹</th>
+                  <th>Eff Rate ₹/kWh</th><th>Δ C9 MoM ₹</th><th>Δ% C9</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
           </div>
         </section>
     </div>
@@ -3050,5 +3080,244 @@
       min-height:auto;
     }
   </style>
+  <script>
+    (()=>{
+      const fmtINR = new Intl.NumberFormat('en-IN',{style:'currency',currency:'INR'});
+      const fmt0  = new Intl.NumberFormat('en-IN',{maximumFractionDigits:0});
+      const fmt2  = new Intl.NumberFormat('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2});
+      // Rates (₹/kWh) should be numeric, not currency:
+      const fmtRate = new Intl.NumberFormat('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2});
+
+      // Load authoritative cell map; warn once if missing or invalid then fall back
+      if(typeof fetch === 'function'){
+        const warnOnce = msg => {
+          if(!window.__analysisMapWarned){
+            console.warn(msg);
+            window.__analysisMapWarned = true;
+          }
+        };
+        fetch('analysis-cell-map.json')
+          .then(r=>r.json())
+          .then(j=>{
+            if(window.validateAnalysisCellMap && !window.validateAnalysisCellMap(j)){
+              warnOnce('[analysis] invalid map; using legacy');
+              return;
+            }
+            if(Array.isArray(j.mismatches) && j.mismatches.length){
+              const details = j.mismatches.map(m=>{
+                if(m && typeof m === 'object' && 'field' in m){
+                  return `${m.field}: expected ${m.expected_cell ?? '?'} → ${m.actual_cell ?? '?'}`;
+                }
+                return '[invalid mismatch entry]';
+              }).join('; ');
+              warnOnce(`[analysis] map loaded with mismatches → ${details}`);
+            }
+            window.__analysisCellMap = j;
+          })
+          .catch(()=>{ warnOnce('[analysis] map missing; using legacy cell addresses'); });
+      }
+
+      function buildCellMap(ws){
+        try{
+          if(ws.__cellMap) return ws.__cellMap;
+          const ref = XLSX.utils.decode_range(ws['!ref'] || 'A1:Z500');
+          let headerRow = -1, colCell = -1, colVal = -1;
+          // 1) Find header row and CELL / VALUE columns
+          for(let R=0; R<=Math.min(ref.e.r, 50); R++){
+            for(let C=0; C<=Math.min(ref.e.c, 16); C++){
+              const cell = ws[XLSX.utils.encode_cell({r:R,c:C})];
+              if(cell && String(cell.v).trim().toUpperCase() === 'CELL'){
+                headerRow = R; colCell = C; colVal = C + 1; break;
+              }
+            }
+            if(colCell >= 0) break;
+          }
+          // Prefer an explicit VALUE header if present on the same header row
+          if(headerRow >= 0){
+            for(let C=0; C<=Math.min(ref.e.c, 16); C++){
+              const vcell = ws[XLSX.utils.encode_cell({r:headerRow,c:C})];
+              if(vcell && String(vcell.v).trim().toUpperCase() === 'VALUE'){ colVal = C; break; }
+            }
+          }
+          // If VALUE not found, try the first numeric-looking column to the right of CELL
+          if(headerRow >= 0 && colCell >= 0 && colVal === colCell + 1){
+            let found = false;
+            for(let C = colCell + 1; C <= Math.min(ref.e.c, 16); C++){
+              // Peek a couple of rows to see if they’re numeric
+              let sawNumeric = 0, sawTotal = 0;
+              for(let R = headerRow + 1; R <= Math.min(headerRow + 6, ref.e.r); R++){
+                const probe = ws[XLSX.utils.encode_cell({r:R,c:C})];
+                if(!probe) continue; sawTotal++;
+                const raw = probe.v ?? probe.w;
+                if(typeof raw === 'number') { sawNumeric++; continue; }
+                if(typeof raw === 'string' && /^[\s+-]?\d+(\.\d+)?$/.test(raw.trim())) sawNumeric++;
+              }
+              if(sawTotal && sawNumeric / sawTotal >= 0.6){ colVal = C; found = true; break; }
+            }
+          }
+          const map = {};
+          if(colCell >= 0){
+            for(let R = headerRow + 1; R <= ref.e.r; R++){
+              const keyCell = ws[XLSX.utils.encode_cell({r:R,c:colCell})];
+              const valCell = ws[XLSX.utils.encode_cell({r:R,c:colVal})];
+              const key = keyCell && String(keyCell.v || keyCell.w || '').trim().toUpperCase();
+              if(!key) continue;
+              let v = 0;
+              if(valCell){
+                if(typeof valCell.v === 'number') v = valCell.v;
+                else if(valCell.v != null || valCell.w != null){
+                  // Only treat as numeric if it looks numeric; avoid coercing "E4" -> 4
+                  const raw = String(valCell.v ?? valCell.w).trim();
+                  const isNum = /^[\s+-]?\d+(\.\d+)?$/.test(raw);
+                  const num = isNum ? parseFloat(raw) : NaN;
+                  v = Number.isFinite(num) ? num : 0;
+                }
+              }
+              map[key] = v;
+            }
+          }
+          ws.__cellMap = map;
+          return map;
+        }catch{ return {}; }
+      }
+
+      function rowGet(ws, addr){
+        const cell = ws && ws[addr];
+        if(cell){
+          const v = cell.v != null ? cell.v : cell.w;
+          if(typeof v === 'number') return v;
+          if(typeof v === 'string'){
+            const num = parseFloat(v.replace(/[^0-9.+-]/g,''));
+            return isFinite(num) ? num : 0;
+          }
+        }
+        const map = buildCellMap(ws);
+        const key = String(addr || '').toUpperCase();
+        return map[key] || 0;
+      }
+
+      // deriveMetrics consults analysis-cell-map.json; falls back to legacy addresses
+      function deriveMetrics(ws){
+        let map;
+        try{
+          map = window.__analysisCellMap?.positional_cells;
+        }catch{ map = null; }
+        const getVal = addr => rowGet(ws, addr);
+        const out = {};
+        if(map && typeof map === 'object'){
+          for(const [field, cell] of Object.entries(map)){
+            const val = getVal(cell);
+            out[field] = val;
+            const short = field.split('_')[0];
+            if(!(short in out)) out[short] = val;
+          }
+        } else {
+          const fields = ['A4','C9','H9','I9','B19','A18','C18','C26'];
+          for(const f of fields){
+            const val = getVal(f);
+            out[f] = val;
+          }
+        }
+        out.eff = out.A4 ? out.C9 / out.A4 : 0;
+        return out;
+      }
+
+      function computeMoM(arr,key){
+        const deltas=[0];
+        for(let i=1;i<arr.length;i++) deltas[i] = arr[i][key] - arr[i-1][key];
+        return deltas;
+      }
+
+      function drawSparkline(host, series, w=900, h=180, pad=24){
+        const min = Math.min(...series);
+        const max = Math.max(...series);
+        const span = max - min || 1;
+        const step = series.length>1 ? (w-2*pad)/(series.length-1) : 0;
+        const pts = series.map((v,i)=>{
+          const x = pad + i*step;
+          const y = h - pad - ((v-min)/span)*(h-2*pad);
+          return `${x},${y}`;
+        }).join(' ');
+        host.innerHTML = `<svg role="img" aria-label="Current Month Bill (C9, INR) trend over months" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">`
+          +`<polyline fill="none" stroke="var(--accent)" stroke-width="2" points="${pts}"/>`
+          +`<line x1="0" x2="${w}" y1="${h-pad}" y2="${h-pad}" stroke="var(--muted)" stroke-width="1"/></svg>`;
+      }
+
+      async function analyzeAllSheets(){
+        return withBusy('analyzeWorkbook', async ()=>{
+          let wb = typeof getWB === 'function' ? getWB() : null;
+          if(!wb || !Object.keys(wb.Sheets||{}).length){
+            const file = document.getElementById('uploadXlsx')?.files?.[0];
+            if(file && await loadXLSX()){
+              const data = new Uint8Array(await file.arrayBuffer());
+              wb = XLSX.read(data,{type:'array'});
+            } else {
+              toast('No workbook loaded...');
+              return;
+            }
+          }
+          const sheets = Object.keys(wb.Sheets).filter(n=>/^\d{4}-\d{2}$/.test(n)).sort();
+          if(!sheets.length){ toast('No YYYY-MM sheets found.'); return; }
+          const rows = sheets.map(name=>({month:name,...deriveMetrics(wb.Sheets[name])}));
+          const deltas = computeMoM(rows,'C9');
+          rows.forEach((r,i)=>{
+            r.deltaC9 = deltas[i];
+            r.deltaPct = i && rows[i-1].C9 ? (deltas[i]/rows[i-1].C9*100) : 0;
+          });
+          window.__analysisRows = rows;
+
+          const tbody = document.querySelector('#analysisTable tbody');
+          if(tbody){
+            tbody.innerHTML='';
+            rows.forEach(r=>{
+              const tr=document.createElement('tr');
+              tr.innerHTML =
+                `<td>${r.month}</td>`+
+                `<td style="text-align:right">${fmt0.format(r.A4)}</td>`+
+                `<td style="text-align:right">${fmtINR.format(r.C9)}</td>`+
+                `<td style="text-align:right">${fmtINR.format(r.H9)}</td>`+
+                `<td style="text-align:right">${fmtINR.format(r.I9)}</td>`+
+                `<td style="text-align:right">${fmtRate.format(r.B19)}</td>`+
+                `<td style="text-align:right">${fmt0.format(r.A18)}</td>`+
+                `<td style="text-align:right">${fmt0.format(r.C18)}</td>`+
+                `<td style="text-align:right">${fmtINR.format(r.C26)}</td>`+
+                `<td style="text-align:right">${fmtRate.format(r.eff)}</td>`+
+                `<td style="text-align:right">${fmtINR.format(r.deltaC9)}</td>`+
+                `<td style="text-align:right">${fmt2.format(r.deltaPct)}%</td>`;
+              tbody.appendChild(tr);
+            });
+          }
+
+          const meta = document.getElementById('analysisMeta');
+          if(meta) meta.textContent = `Sheets analyzed: ${rows.length} • Range: ${rows[0].month} → ${rows[rows.length-1].month}`;
+          drawSparkline(document.getElementById('analysisChartHost'), rows.map(r=>r.C9));
+          const card = document.getElementById('analysisCard');
+          if(card) card.hidden = false;
+        });
+      }
+
+      function exportAnalysisCsv(){
+        const rows = window.__analysisRows;
+        if(!rows || !rows.length){ toast('No analysis data to export.'); return; }
+        const header = ['Month','A4_kWh','C9_INR','H9_INR','I9_INR','B19_RsPerKWh','A18_kWh','C18_kWh','C26_INR','EffRate_RsPerKWh','DeltaC9_INR','DeltaC9_pct'];
+        const lines = [header.join(',')];
+        rows.forEach(r=>{
+          lines.push([r.month,r.A4,r.C9,r.H9,r.I9,r.B19,r.A18,r.C18,r.C26,r.eff,r.deltaC9,r.deltaPct].join(','));
+        });
+        const blob = new Blob([lines.join('\n')],{type:'text/csv'});
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = 'WEG_Analysis.csv';
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(()=>{URL.revokeObjectURL(a.href);a.remove();},0);
+      }
+
+      document.addEventListener('DOMContentLoaded',()=>{
+        document.getElementById('analyzeWorkbook')?.addEventListener('click', analyzeAllSheets);
+        document.getElementById('exportAnalysisCsv')?.addEventListener('click', exportAnalysisCsv);
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/analysis-cell-map.json
+++ b/analysis-cell-map.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "positional_cells": {
+    "A4_kWh": "A4",
+    "C9_CurrentMonthBill_INR": "C9",
+    "H9_NetPayable_INR": "H9",
+    "I9_ActualPaid_INR": "I9",
+    "B19_WindRate_RsPerKWh": "B19",
+    "A18_Bitlavadia_kWh": "A18",
+    "C18_Nanisindhodi_kWh": "C18",
+    "C26_NetWindCredit_INR": "C26"
+  },
+  "derived": {
+    "A9_TotConsumptionCharge": "A9 = B4+C4+D4+E4−F4−G4+H4+I4",
+    "B9_ED_20pct": "B9 = A9×0.2",
+    "C9_CurrentMonthBill": "C9 = A9+B9",
+    "A19_TotalAllocated": "A19 = A18+C18",
+    "B19_WindRate": "B19 = IF(A19=0,0,C26/A19)"
+  },
+  "tidy_export": {
+    "has_header_row": true,
+    "cell_column_header": "CELL",
+    "value_column_header": "VALUE",
+    "cell_col_letter": "C",
+    "value_col_letter": "D"
+  },
+  "mismatches": []
+}

--- a/scripts/analysisCellMap.ts
+++ b/scripts/analysisCellMap.ts
@@ -1,0 +1,35 @@
+export interface AnalysisCellMap {
+  version: number;
+  positional_cells: {
+    A4_kWh: string;
+    C9_CurrentMonthBill_INR: string;
+    H9_NetPayable_INR: string;
+    I9_ActualPaid_INR: string;
+    B19_WindRate_RsPerKWh: string;
+    A18_Bitlavadia_kWh: string;
+    C18_Nanisindhodi_kWh: string;
+    C26_NetWindCredit_INR: string;
+  };
+  derived: Record<string, string>;
+  tidy_export: {
+    has_header_row: boolean;
+    cell_column_header: string;
+    value_column_header: string;
+    cell_col_letter: string;
+    value_col_letter: string;
+  };
+  mismatches?: { field: string; expected_cell: string; actual_cell: string; fix: string }[];
+}
+
+export function validateAnalysisCellMap(data: unknown): data is AnalysisCellMap {
+  try {
+    const m = data as AnalysisCellMap;
+    return m.version === 1 &&
+      typeof m.positional_cells?.A4_kWh === 'string' &&
+      typeof m.positional_cells?.C9_CurrentMonthBill_INR === 'string' &&
+      typeof m.tidy_export?.cell_column_header === 'string' &&
+      typeof m.tidy_export?.value_column_header === 'string';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add toolbar Analysis menu with workbook trend and CSV export actions
- compute monthly metrics across YYYY-MM sheets and render table + sparkline
- enable exporting analysis results to WEG_Analysis.csv
- display rate metrics as decimals and clarify sparkline label
- map tidy-sheet VALUE column to avoid misreading cell codes
- document authoritative cell mapping for analysis with TypeScript validator
- source deriveMetrics from analysis-cell-map.json for easy KPI expansion
- log warnings when analysis-cell-map.json is missing or invalid
- warn only once per session if analysis-cell-map.json is missing or invalid
- surface mapping mismatches in analysis warnings
- harden mismatch logging to guard against malformed entries
- simplify fallback message for invalid mismatch entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2df8aba84833392c8e724869ff861