### PR TITLE
fix: lock analysis value column and ignore cell references

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -3130,43 +3130,44 @@
           if(ws.__cellMap) return ws.__cellMap;
           const ref = XLSX.utils.decode_range(ws['!ref'] || 'A1:Z500');
           let headerRow = -1, colCell = -1, colVal = -1;
-          // 1) Find header row and CELL / VALUE columns
+          // 1) Find header row and the column containing "CELL"
           for(let R=0; R<=Math.min(ref.e.r, 50); R++){
             for(let C=0; C<=Math.min(ref.e.c, 16); C++){
               const cell = ws[XLSX.utils.encode_cell({r:R,c:C})];
               if(cell && String(cell.v).trim().toUpperCase() === 'CELL'){
                 headerRow = R; colCell = C;
-                // Numeric values live immediately right of CELL (e.g., C -> D).
-                // The following column (typically E) holds UNITS/NOTES and is ignored.
+                // Numeric values are the column immediately to the right of CELL.
                 colVal = C + 1;
                 break;
               }
             }
             if(colCell >= 0) break;
           }
-          // Prefer an explicit VALUE header if present on the same header row.
-          // "UNITS/NOTES" is not a numeric column and must be ignored.
-          if(headerRow >= 0){
-            for(let C=0; C<=Math.min(ref.e.c, 16); C++){
-              const vcell = ws[XLSX.utils.encode_cell({r:headerRow,c:C})];
-              const hv = vcell && String(vcell.v).trim().toUpperCase();
-              if(hv === 'VALUE'){ colVal = C; break; }
-            }
+          // 2) If a header says UNITS/NOTES, never use it as numeric source
+          const headerText = (c)=> {
+            const h = ws[XLSX.utils.encode_cell({r:headerRow,c:c})];
+            return h ? String(h.v).trim().toUpperCase() : '';
+          };
+          if (headerRow >= 0 && headerText(colVal) === 'UNITS/NOTES') {
+            // Keep colVal fixed at CELL+1; do not drift into UNITS/NOTES.
           }
-          // If we still haven't confirmed, sniff to the right of CELL as a last resort.
-          // This preserves robustness for atypical sheets while preferring our layout.
+          // 3) As a last resort for atypical sheets, sniff to the right of CELL
           if(headerRow >= 0 && colCell >= 0 && colVal === colCell + 1){
             let found = false;
             for(let C = colCell + 1; C <= Math.min(ref.e.c, 16); C++){
-              // Peek a couple of rows to see if they're numeric
+              if (headerText(C) === 'UNITS/NOTES') continue; // never treat as numeric
               let sawNumeric = 0, sawTotal = 0;
               for(let R = headerRow + 1; R <= Math.min(headerRow + 6, ref.e.r); R++){
                 const probe = ws[XLSX.utils.encode_cell({r:R,c:C})];
                 if(!probe) continue; sawTotal++;
                 const n = normalizeNumber(probe.v ?? probe.w);
-                if(Number.isFinite(n) && n !== 0) sawNumeric++;
+                if(Number.isFinite(n)) sawNumeric++;
               }
               if(sawTotal && sawNumeric / sawTotal >= 0.6){ colVal = C; found = true; break; }
+            }
+            if(found && colVal !== colCell + 1 && !window.__analysisColValWarned){
+              console.warn(`[analysis] value column auto-detected: ${XLSX.utils.encode_col(colVal)} (fallback)`);
+              window.__analysisColValWarned = true;
             }
           }
           const map = {};
@@ -3189,8 +3190,20 @@
         const cell = ws && ws[addr];
         if(cell){
           const v = cell.v != null ? cell.v : cell.w;
-          const num = normalizeNumber(v);
-          if(num || num === 0) return num;
+          // If the cell contains an A1-style token (e.g., "C9"), do NOT coerce it to 9.
+          // This forces lookup via the (CELL -> numeric value) table in buildCellMap.
+          if (typeof v === 'string') {
+            const a1 = /^[A-Z]{1,3}\d+$/i.test(v.trim());
+            if (a1) {
+              // fall through to map-based read
+            } else {
+              const num = normalizeNumber(v);
+              if (Number.isFinite(num)) return num;
+            }
+          } else {
+            const num = normalizeNumber(v);
+            if (Number.isFinite(num)) return num;
+          }
         }
         const map = buildCellMap(ws);
         const key = String(addr || '').toUpperCase();


### PR DESCRIPTION
## Summary
- ensure analysis uses column immediately right of CELL for numeric KPIs
- ignore UNITS/NOTES headers and log when fallback sniff chooses a different column
- bypass numeric parsing of A1-style cell references and treat zeros as numeric during fallback sniff

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c335a050833390e9d5b8ae4242c6