### PR TITLE
fix: treat PF slab1 as credit

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -1060,7 +1060,7 @@
       EC_SLAB1: 'KWh billed.',
       TOD_PEAK: 'Hint: from “TOU” (HT Bill → H4)',
       TOD_NIGHT_REBATE: 'Qty auto = EC_SLAB1 Amt (D)',
-      PF_CHARGE_SLAB1: 'Qty auto = EC_SLAB1 Amt (D); PF rate acts as a multiplier',
+      PF_CHARGE_SLAB1: 'Qty auto = EC_SLAB1 Amt (D); PF rate acts as a multiplier (credit)',
       ARREAR_ED: 'Hint: Enter Consumption Charges (base for ED)'
     };
     const QTY_PLACEHOLDERS = {
@@ -1298,8 +1298,8 @@
           F=D;
         }else{
           D=B*C;
-          // Ensure Night Rebate is a credit (negative amount & SES):
-          if (s.code==='TOD_NIGHT_REBATE') {
+          // Ensure Night Rebate and PF Charge Slab 1 are credits (negative amounts & SES):
+          if (s.code==='TOD_NIGHT_REBATE' || s.code==='PF_CHARGE_SLAB1') {
             D = -Math.abs(D);
           }
           F=E?D/E:0;

--- a/test/sample-bill.spec.js
+++ b/test/sample-bill.spec.js
@@ -59,7 +59,7 @@ test('reference bill calculations', async () => {
   close(amt('TOD_NIGHT_REBATE'), -1 * qty('TOD_NIGHT_REBATE') * 1.5);
   close(qty('PF_CHARGE_SLAB1'), 6229914.60);
   close(tar('PF_CHARGE_SLAB1'), 2.35);
-  close(amt('PF_CHARGE_SLAB1'), qty('PF_CHARGE_SLAB1') * 2.35);
+  close(amt('PF_CHARGE_SLAB1'), -1 * qty('PF_CHARGE_SLAB1') * 2.35);
   close(qty('ARREAR_ED'), 10924059.54);
   close(tar('ARREAR_ED'), 0.2);
   close(amt('ARREAR_ED'), 2184811.91);
@@ -70,7 +70,7 @@ test('reference bill calculations', async () => {
   close(qty('TOD_NIGHT_REBATE'), 6229914.60);
   close(amt('TOD_NIGHT_REBATE'), -1 * qty('TOD_NIGHT_REBATE') * 1.5);
   close(qty('PF_CHARGE_SLAB1'), 6229914.60);
-  close(amt('PF_CHARGE_SLAB1'), qty('PF_CHARGE_SLAB1') * 2.35);
+  close(amt('PF_CHARGE_SLAB1'), -1 * qty('PF_CHARGE_SLAB1') * 2.35);
   close(qty('ARREAR_ED'), 10929059.54);
   close(amt('ARREAR_ED'), 2185811.91);
 });


### PR DESCRIPTION
## Summary
- treat PF Charge Slab 1 amount as credit alongside TOD Night Rebate
- clarify PF Charge Slab 1 hint and update sample bill test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5669905a48333bee64126a77a3443