### PR TITLE
feat: allow negative values for advance adjustment

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -1414,6 +1414,7 @@
     function validate(){
       let ok = true;
       const percentIds = ['B15','D15','C16'];
+      const negativeOkIds = ['G9'];
       document.querySelectorAll('input').forEach(el=>{
         if(el.type==='month' || el.type==='file') return;
         const hint = el.nextElementSibling;
@@ -1430,7 +1431,7 @@
 
         if (percentIds.includes(el.id)) {
           if (val < 0 || val > 100) { hint.textContent='0–100 only.'; hint.style.display='block'; el.classList.add('invalid'); ok = false; }
-        } else if (val < 0) {
+        } else if (!negativeOkIds.includes(el.id) && val < 0) {
           hint.textContent='≥ 0 only.'; hint.style.display='block'; el.classList.add('invalid'); ok = false;
         }
       });


### PR DESCRIPTION
## Summary
- allow negative numbers in the Advance Payment/Adjust (G9) field by introducing negative field exceptions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b56e0434248333aaafd9c9603b3336