### PR TITLE
style: polish Rates Manager table

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -366,6 +366,48 @@
     flex-wrap:wrap;
   }
 </style>
+<style>
+  .table-wrap{
+    overflow:auto;
+    border-radius:8px;
+    background:linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,.02));
+    border:1px solid rgba(255,255,255,.08);
+    box-shadow:var(--shadow);
+  }
+  table.data{
+    width:100%;
+    border-collapse:collapse;
+    font-size:12px;
+  }
+  table.data thead th{
+    position:sticky;top:0;
+    background:rgba(15,23,42,.85);
+    border-bottom:1px solid rgba(255,255,255,.1);
+    backdrop-filter:blur(4px);
+    z-index:1;
+  }
+  table.data tbody tr:nth-child(even){background:rgba(255,255,255,.03);}
+  table.data tbody tr:hover{background:rgba(255,255,255,.06);}
+  table.data th, table.data td{padding:4px 6px;}
+  table.data .num{text-align:right;font-variant-numeric:tabular-nums;}
+  table.data input[type="number"]{
+    width:100%;
+    max-width:100px;
+    padding:2px 4px;
+    height:24px;
+    border-radius:6px;
+    border:1px solid rgba(255,255,255,.15);
+    background:rgba(17,24,39,.6);
+    color:var(--ink);
+    text-align:right;
+  }
+  @media(max-width:480px){
+    table.data input[type="number"]{max-width:80px;}
+  }
+  .good{color:var(--good);}
+  .bad{color:var(--bad);}
+  .muted{color:var(--muted);}
+</style>
 </head>
 <body>
   <div class="wrap">
@@ -579,20 +621,22 @@
             <button id="exportCsv" class="ghost">Export CSV</button>
           </div>
           <div class="hr"></div>
-          <table id="ratesTable" style="width:100%;border-collapse:collapse;font-size:12px;">
-            <thead>
-              <tr>
-                <th style="text-align:left;">Service</th>
-                <th>Qty (B)</th>
-                <th>Tariff (C)</th>
-                <th>Amt (D)</th>
-                <th>Contract Rate (E)</th>
-                <th>Unit Adj (F)</th>
-                <th>Amount SES (G)</th>
-              </tr>
-            </thead>
-            <tbody id="ratesBody"></tbody>
-          </table>
+          <div class="table-wrap">
+            <table id="ratesTable" class="data">
+              <thead>
+                <tr>
+                  <th style="text-align:left;">Service</th>
+                  <th class="num">Qty (B)</th>
+                  <th class="num">Tariff (C)</th>
+                  <th class="num">Amt (D)</th>
+                  <th class="num">Contract Rate (E)</th>
+                  <th class="num">Unit Adj (F)</th>
+                  <th class="num">Amount SES (G)</th>
+                </tr>
+              </thead>
+              <tbody id="ratesBody"></tbody>
+            </table>
+          </div>
           <div id="parityBadge" class="pill" style="margin-top:8px;">ΣD ₹0.00 | ΣG ₹0.00 | Δ ₹0.00</div>
           <input type="file" id="ratesFile" accept="application/json" style="display:none" multiple>
         </section>
@@ -1153,12 +1197,12 @@
         const ph = QTY_PLACEHOLDERS[s.code] ? `placeholder="${QTY_PLACEHOLDERS[s.code]}"` : '';
         tr.innerHTML=`
           <td><span class="mono">${s.code}</span><div class="muted">${s.name}</div>${hintHtml}</td>
-          <td><input type="number" ${qtyAttrs} id="qty_${s.code}" ${qtyDis} ${ph}/></td>
-          <td><input type="number" step="0.000001" id="tar_${s.code}" disabled/></td>
-          <td><span id="d_${s.code}" class="muted">—</span></td>
-          <td><input type="number" step="0.000001" id="po_${s.code}" disabled/></td>
-          <td><span id="f_${s.code}" class="muted">—</span></td>
-          <td><span id="g_${s.code}" class="muted">—</span></td>`;
+          <td class="num"><input type="number" ${qtyAttrs} id="qty_${s.code}" ${qtyDis} ${ph}/></td>
+          <td class="num"><input type="number" step="0.000001" id="tar_${s.code}" disabled/></td>
+          <td class="num"><span id="d_${s.code}" class="muted">—</span></td>
+          <td class="num"><input type="number" step="0.000001" id="po_${s.code}" disabled/></td>
+          <td class="num"><span id="f_${s.code}" class="muted">—</span></td>
+          <td class="num"><span id="g_${s.code}" class="muted">—</span></td>`;
         body.appendChild(tr);
       });
       SERVICE_LIST.forEach(s=>{
@@ -1308,9 +1352,19 @@
         G=(s.code==='WIND_ENERGY_CREDIT'||s.code.startsWith('ARREAR_'))?D:E*F;
         totalD+=D; totalG+=G;
         sesRows.push({code:s.code,name:s.name,qty:B,amt:D,adj:F,rate:E,ses:G});
-        if(dEl) dEl.textContent = Math.abs(D)<0.005 ? '—' : INR.format(D);
+        if(dEl){
+          dEl.textContent = Math.abs(D)<0.005 ? '—' : INR.format(D);
+          dEl.classList.toggle('bad', D < -0.004);
+          dEl.classList.toggle('good', D > 0.004);
+          dEl.classList.toggle('muted', Math.abs(D) <= 0.004);
+        }
         if(fEl){const prec=2; fEl.textContent=Math.abs(F)<0.005?'—':F.toFixed(prec);}
-        if(gEl) gEl.textContent = Math.abs(G)<0.005 ? '—' : INR.format(G);
+        if(gEl){
+          gEl.textContent = Math.abs(G)<0.005 ? '—' : INR.format(G);
+          gEl.classList.toggle('bad', G < -0.004);
+          gEl.classList.toggle('good', G > 0.004);
+          gEl.classList.toggle('muted', Math.abs(G) <= 0.004);
+        }
       });
       const badge=$('parityBadge');
       if(badge){


### PR DESCRIPTION
## Summary
- style: add sticky header, zebra striping, and input tweaks for Rates Manager
- feat: tint debit/credit amounts green/red based on sign
- chore: remove redundant inline style from Rates table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5744b2e18833385974e979684412f