### PR TITLE
fix: stabilize finance readiness badge

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -1356,8 +1356,11 @@
     #financeReadinessBadge{
       display:inline-flex;
       align-items:center;
+      justify-content:flex-start;
       gap:6px;
       min-width:0;
+      box-sizing:border-box;
+      min-inline-size:calc(7ch + 42px);
       height:22px;
       padding:0 8px;
       border-radius:999px;
@@ -1367,6 +1370,19 @@
       line-height:1;
       white-space:nowrap;
       flex:0 0 auto;
+    }
+    #financeReadinessBadge::after{
+      content:"";
+      width:7px;
+      height:7px;
+      flex:0 0 7px;
+      visibility:hidden;
+    }
+    #financeReadinessState{
+      display:block;
+      min-width:0;
+      flex:1 1 auto;
+      text-align:center;
     }
     #financeReadinessBadge .status-dot{
       width:7px;

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,99 +1,104 @@
 ## Summary
 
-This branch moves the IOM finance cutoff warning from the lower `Certification & Attachments` section to the top portion of the generated IOM/PDF.
+This branch stabilizes the finance readiness badge shown inside the `Make IOM` toolbar control.
 
-The warning text itself is unchanged. The change is purely about document placement and visibility.
+Before this change, the badge text switched between `Ready` and `Blocked`, and because those labels are different widths, the `Make IOM` summary would subtly resize. That caused neighboring toolbar items like `Configuration` and `More` to shift horizontally, creating a visible "wiggle" in the header.
 
-After this update, the warning now appears:
-- immediately below the payee / bank information bar
-- before the `Amount Mapping (per formula)` section
+This update removes that movement while preserving the existing readiness wording and logic.
 
 ## Why
 
-The due-date cutoff warning is one of the most operationally important instructions in the IOM:
-- it is finance-facing
-- it is time-sensitive
-- it directly warns about delayed payment charges if payment is credited after `16:00 hrs IST` on the Due Date
+`Make IOM` is a high-traffic toolbar control, and the finance readiness state is expected to change as users fill in or correct required fields.
 
-Previously, the note appeared lower in the document inside `Certification & Attachments`, which made it easier to miss while reading the IOM top-down.
+The old behavior created two UX problems:
+- the top toolbar felt visually unstable because adjacent menus moved when the readiness label changed
+- the badge itself did not keep the state text in a stable visual center once width reservation was introduced
 
-Moving it upward improves the document flow because the instruction now appears next to the payment context users are already reading:
-- payee details
-- vendor code
-- bank account / IFSC / branch details
-
-This gives the finance warning earlier visual priority and makes the IOM more usable as a payment-processing document.
+The final implementation fixes both of those issues and also avoids a new accessibility pitfall where a hard-coded width could clip `Blocked` for users with larger effective font sizes.
 
 ## What Changed
 
-### IOM template
+### Toolbar badge stabilization
 
 In `1.4.1 GUI Entry.html`:
-- inserted the existing `IMPORTANT (Finance)` warning directly after the `.info-bar`
-- removed the same warning from the lower `Certification & Attachments` footer-note block
-- kept the text content unchanged
-- kept `data-testid="due-date-cutoff-note"` unchanged
+- the finance readiness badge now reserves a font-aware minimum width instead of sizing directly off the current label text
+- the badge content is laid out so the visible state text stays centered even though the status dot appears on the left
+- a hidden trailing spacer equal to the dot width balances the badge, so `Ready` and `Blocked` occupy the same visual center
 
-This means the change is limited to rendered document order; it does not alter business logic, data binding, or note wording.
+This keeps the toolbar stable without changing the actual state text.
 
-### Test coverage
+### Accessibility-safe sizing
 
-Updated `test/basic.test.js` to protect the new placement.
+The final implementation intentionally uses:
+- `min-inline-size` instead of a hard fixed width
+- `flex: 0 0 auto` instead of a rigid badge cap
 
-The test now verifies that the due-date cutoff note:
-- still renders
-- still includes the expected cutoff wording
-- still includes the formatted due date
-- appears after `.info-bar`
-- appears before `.mapping`
+Why this matters:
+- the toolbar still avoids width jitter in normal use
+- the badge can grow if browser font metrics are larger than expected
+- `Blocked` will not be clipped for users who enable larger minimum font sizes or other text-scaling behavior
 
-This helps prevent future regressions where the note gets pushed back into the lower certification block or otherwise loses its intended prominence.
+### No logic changes
+
+This branch does **not** change:
+- finance readiness computation
+- `Ready` / `Blocked` wording
+- badge color semantics
+- IOM gating behavior
+- toolbar structure or menu behavior
+
+This is a focused presentation-layer fix for badge stability.
+
+## Test Coverage
+
+Updated `test/readiness-ux.spec.js` to lock in the new behavior with source-level regression checks.
+
+The new assertions verify that:
+- the finance readiness badge reserves a font-aware minimum width
+- the badge includes a hidden balancing spacer matching the left status dot
+- the readiness label is a flexing centered item inside the badge slot
+
+This gives us stable regression coverage without relying on brittle layout measurements in JSDOM.
 
 ## User-Facing Impact
 
 ### Before
-- finance warning was buried in the lower certification area
-- warning appeared after the mapping section
-- users had to read deeper into the document to encounter the cutoff instruction
+- `Ready` / `Blocked` changes could make `Configuration` and `More` shift sideways
+- the toolbar looked slightly unstable during readiness updates
+- early attempts to stabilize width risked clipping under larger font settings
 
 ### After
-- finance warning appears near the top of the IOM
-- warning is seen alongside payment destination / banking details
-- the payment-risk instruction is harder to overlook during processing
-
-## Scope
-
-This branch does **not** change:
-- the wording of the finance cutoff note
-- due-date calculation or validation rules
-- finance-readiness gating logic
-- IOM amount mapping logic
-- signatures, receipt note, or attachment content
-- PDF generation behavior apart from the note’s position in the rendered document
-
-## Risk / Notes
-
-This is a low-risk presentation change, but one practical note remains:
-- because the warning now appears earlier on the page, very dense IOM layouts should still be visually checked for pagination balance when long bank/location strings are present
-
-Functionally, the change is intentionally narrow.
+- `Configuration` and `More` stay put
+- the `Make IOM` badge still shows the same readiness state
+- `Ready` and `Blocked` remain visually centered within the badge
+- the badge can grow when larger font metrics require it
 
 ## Validation
 
 Validated locally with:
 
 ```bash
+node --test test/readiness-ux.spec.js
 npm test
 ```
 
-Result:
-- `14/14` tests passed
-
-Additional focused validation:
-- `test/basic.test.js` passed with explicit DOM-order assertions for the moved warning
+Results:
+- `test/readiness-ux.spec.js` passed
+- full test suite passed (`14/14`)
 
 ## Files Changed
 
 - `1.4.1 GUI Entry.html`
-- `test/basic.test.js`
+- `test/readiness-ux.spec.js`
 - `pr_body.md`
+
+## Notes
+
+This is a low-risk UI polish branch.
+
+The change is intentionally narrow, but it is still worth visually checking the toolbar across:
+- multiple themes
+- browser zoom levels
+- fallback fonts / minimum font-size settings
+
+That said, the implementation is specifically designed to behave better under those conditions than the earlier fixed-width approach.

--- a/test/readiness-ux.spec.js
+++ b/test/readiness-ux.spec.js
@@ -232,6 +232,24 @@ test('toolbar shows consolidated workbook, make iom, configuration, and more men
   assert.equal(doc.getElementById('openConfigMenu'), null, 'More should no longer contain a configuration launcher');
 });
 
+test('finance readiness badge reserves fixed width so toolbar neighbors do not wiggle', () => {
+  assert.match(
+    htmlSource,
+    /#financeReadinessBadge\{[\s\S]*?justify-content:flex-start;[\s\S]*?min-inline-size:calc\(7ch \+ 42px\);[\s\S]*?flex:0 0 auto;/,
+    'Finance readiness badge should reserve a font-aware minimum width for Ready and Blocked states'
+  );
+  assert.match(
+    htmlSource,
+    /#financeReadinessBadge::after\{[\s\S]*?flex:0 0 7px;[\s\S]*?visibility:hidden;/,
+    'Finance readiness badge should balance the left status dot with an equal invisible spacer'
+  );
+  assert.match(
+    htmlSource,
+    /#financeReadinessState\{[\s\S]*?display:block;[\s\S]*?flex:1 1 auto;[\s\S]*?text-align:center;/,
+    'Finance readiness label should fill the reserved slot and stay centered within the badge'
+  );
+});
+
 test('workbook menu includes sheet, workbook, and analysis actions', async () => {
   const dom = await bootDom();
   const doc = dom.window.document;


### PR DESCRIPTION
## Summary

This branch stabilizes the finance readiness badge shown inside the `Make IOM` toolbar control.

Before this change, the badge text switched between `Ready` and `Blocked`, and because those labels are different widths, the `Make IOM` summary would subtly resize. That caused neighboring toolbar items like `Configuration` and `More` to shift horizontally, creating a visible "wiggle" in the header.

This update removes that movement while preserving the existing readiness wording and logic.

## Why

`Make IOM` is a high-traffic toolbar control, and the finance readiness state is expected to change as users fill in or correct required fields.

The old behavior created two UX problems:
- the top toolbar felt visually unstable because adjacent menus moved when the readiness label changed
- the badge itself did not keep the state text in a stable visual center once width reservation was introduced

The final implementation fixes both of those issues and also avoids a new accessibility pitfall where a hard-coded width could clip `Blocked` for users with larger effective font sizes.

## What Changed

### Toolbar badge stabilization

In `1.4.1 GUI Entry.html`:
- the finance readiness badge now reserves a font-aware minimum width instead of sizing directly off the current label text
- the badge content is laid out so the visible state text stays centered even though the status dot appears on the left
- a hidden trailing spacer equal to the dot width balances the badge, so `Ready` and `Blocked` occupy the same visual center

This keeps the toolbar stable without changing the actual state text.

### Accessibility-safe sizing

The final implementation intentionally uses:
- `min-inline-size` instead of a hard fixed width
- `flex: 0 0 auto` instead of a rigid badge cap

Why this matters:
- the toolbar still avoids width jitter in normal use
- the badge can grow if browser font metrics are larger than expected
- `Blocked` will not be clipped for users who enable larger minimum font sizes or other text-scaling behavior

### No logic changes

This branch does **not** change:
- finance readiness computation
- `Ready` / `Blocked` wording
- badge color semantics
- IOM gating behavior
- toolbar structure or menu behavior

This is a focused presentation-layer fix for badge stability.

## Test Coverage

Updated `test/readiness-ux.spec.js` to lock in the new behavior with source-level regression checks.

The new assertions verify that:
- the finance readiness badge reserves a font-aware minimum width
- the badge includes a hidden balancing spacer matching the left status dot
- the readiness label is a flexing centered item inside the badge slot

This gives us stable regression coverage without relying on brittle layout measurements in JSDOM.

## User-Facing Impact

### Before
- `Ready` / `Blocked` changes could make `Configuration` and `More` shift sideways
- the toolbar looked slightly unstable during readiness updates
- early attempts to stabilize width risked clipping under larger font settings

### After
- `Configuration` and `More` stay put
- the `Make IOM` badge still shows the same readiness state
- `Ready` and `Blocked` remain visually centered within the badge
- the badge can grow when larger font metrics require it

## Validation

Validated locally with:

```bash
node --test test/readiness-ux.spec.js
npm test
```

Results:
- `test/readiness-ux.spec.js` passed
- full test suite passed (`14/14`)

## Files Changed

- `1.4.1 GUI Entry.html`
- `test/readiness-ux.spec.js`
- `pr_body.md`

## Notes

This is a low-risk UI polish branch.

The change is intentionally narrow, but it is still worth visually checking the toolbar across:
- multiple themes
- browser zoom levels
- fallback fonts / minimum font-size settings

That said, the implementation is specifically designed to behave better under those conditions than the earlier fixed-width approach.
