### PR TITLE
Refine header accent integration

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -1886,10 +1886,16 @@
       header::before{
         content:"";
         position:absolute;
-        left:0;
+        left:18px;
         top:0;
-        width:100%;
-        height:3px;
+        width:min(clamp(170px, 28vw, 340px), calc(100% - 36px));
+        height:8px;
+        border-radius:0 0 14px 14px;
+        box-shadow:
+          0 8px 18px rgba(2,6,10,.14),
+          inset 0 1px 0 rgba(255,255,255,.08);
+        opacity:.96;
+        pointer-events:none;
         background:linear-gradient(90deg, rgba(211,154,88,.75), rgba(211,154,88,.12) 55%, rgba(129,149,172,.42));
       }
 

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,104 +1,120 @@
 ## Summary
 
-This branch stabilizes the finance readiness badge shown inside the `Make IOM` toolbar control.
+This branch refines the visual treatment of the sticky header card that contains the `WEG Billing Calculator` title.
 
-Before this change, the badge text switched between `Ready` and `Blocked`, and because those labels are different widths, the `Make IOM` summary would subtly resize. That caused neighboring toolbar items like `Configuration` and `More` to shift horizontally, creating a visible "wiggle" in the header.
+The issue reported during review was a thick line appearing above the top menu/title card, making the header feel visually detached from the rest of the card surface. The previous implementation used a full-width `header::before` accent strip, which read more like a separate slab sitting on top of the card than an integrated detail.
 
-This update removes that movement while preserving the existing readiness wording and logic.
+This update replaces that full-width strip with a shorter, integrated accent tab so the header keeps its industrial styling without looking improperly assembled.
 
-## Why
+## Problem
 
-`Make IOM` is a high-traffic toolbar control, and the finance readiness state is expected to change as users fill in or correct required fields.
+Before this change:
 
-The old behavior created two UX problems:
-- the top toolbar felt visually unstable because adjacent menus moved when the readiness label changed
-- the badge itself did not keep the state text in a stable visual center once width reservation was introduced
+- the header rendered a bright, full-width accent line across the top edge
+- that line visually competed with the existing border and inset highlight already used by the card
+- the combination made the `WEG Billing Calculator` panel look like it had an extra layer placed on top of it
+- after the first pass at softening the line, the result became too understated and lost the intentional visual character of the header
 
-The final implementation fixes both of those issues and also avoids a new accessibility pitfall where a hard-coded width could clip `Blocked` for users with larger effective font sizes.
+The final goal for this branch was not simply to remove the line, but to make the top accent feel deliberate, integrated, and visually "cool" again.
+
+## Final Approach
+
+The header accent is still implemented through `header::before`, but its geometry and presentation were reworked:
+
+- the accent no longer spans the full width of the header
+- it now starts inset from the left edge
+- it uses a compact width that scales responsively instead of stretching across the whole card
+- its height was increased from a hairline into a small top tab
+- a rounded lower edge was added so the shape feels attached to the header card
+- a subtle shadow and inner highlight were added so the accent feels like a built-in piece of the panel rather than a painted rule
+
+The original theme-driven gradient was preserved, so the accent still participates in the industrial palette and remains consistent with the existing brand/header styling.
 
 ## What Changed
 
-### Toolbar badge stabilization
-
 In `1.4.1 GUI Entry.html`:
-- the finance readiness badge now reserves a font-aware minimum width instead of sizing directly off the current label text
-- the badge content is laid out so the visible state text stays centered even though the status dot appears on the left
-- a hidden trailing spacer equal to the dot width balances the badge, so `Ready` and `Blocked` occupy the same visual center
 
-This keeps the toolbar stable without changing the actual state text.
+- updated the `header::before` pseudo-element used for the top accent treatment
+- changed the accent from:
+  - full-width
+  - 3px tall
+  - flat line styling
+- to a new treatment that is:
+  - left-inset
+  - responsive in width
+  - 8px tall
+  - rounded at the bottom corners
+  - lightly shadowed and highlighted
+  - explicitly non-interactive with `pointer-events:none`
 
-### Accessibility-safe sizing
+## What Did Not Change
 
-The final implementation intentionally uses:
-- `min-inline-size` instead of a hard fixed width
-- `flex: 0 0 auto` instead of a rigid badge cap
+This branch does not change:
 
-Why this matters:
-- the toolbar still avoids width jitter in normal use
-- the badge can grow if browser font metrics are larger than expected
-- `Blocked` will not be clipped for users who enable larger minimum font sizes or other text-scaling behavior
+- header layout structure
+- toolbar controls
+- menu behavior
+- theme selection logic
+- brand/title copy
+- any business logic, calculations, or export workflows
+- any test behavior outside of re-running the existing suite for regression confidence
 
-### No logic changes
-
-This branch does **not** change:
-- finance readiness computation
-- `Ready` / `Blocked` wording
-- badge color semantics
-- IOM gating behavior
-- toolbar structure or menu behavior
-
-This is a focused presentation-layer fix for badge stability.
-
-## Test Coverage
-
-Updated `test/readiness-ux.spec.js` to lock in the new behavior with source-level regression checks.
-
-The new assertions verify that:
-- the finance readiness badge reserves a font-aware minimum width
-- the badge includes a hidden balancing spacer matching the left status dot
-- the readiness label is a flexing centered item inside the badge slot
-
-This gives us stable regression coverage without relying on brittle layout measurements in JSDOM.
+This is a presentation-only polish change scoped to the header accent detail.
 
 ## User-Facing Impact
 
 ### Before
-- `Ready` / `Blocked` changes could make `Configuration` and `More` shift sideways
-- the toolbar looked slightly unstable during readiness updates
-- early attempts to stabilize width risked clipping under larger font settings
+
+- the title/header card looked like it had a separate thick strip pasted on top
+- the top edge drew too much attention away from the actual title and controls
+- a first softening pass removed the harshness, but also removed too much personality
 
 ### After
-- `Configuration` and `More` stay put
-- the `Make IOM` badge still shows the same readiness state
-- `Ready` and `Blocked` remain visually centered within the badge
-- the badge can grow when larger font metrics require it
+
+- the `WEG Billing Calculator` card reads as a single integrated panel
+- the header keeps a distinct styled accent without the detached-strip look
+- the top detail feels more intentional and decorative instead of accidental
+- the visual hierarchy shifts back toward the title and toolbar content
+
+## Implementation Notes
+
+The update intentionally keeps the existing gradient colors:
+
+- copper-toned primary accent
+- steel-toned trailing fade
+
+That means the change improves the shape language of the header without forcing a broader retune of the active theme system.
+
+The resulting accent behaves more like a design tab or integrated plate than a border override, which better matches the industrial control-panel style already present in the page chrome.
 
 ## Validation
 
 Validated locally with:
 
 ```bash
-node --test test/readiness-ux.spec.js
 npm test
 ```
 
-Results:
-- `test/readiness-ux.spec.js` passed
+Result:
+
 - full test suite passed (`14/14`)
+
+## Risk Assessment
+
+Risk is low because:
+
+- only CSS for the header accent pseudo-element changed
+- no DOM structure changed
+- no JavaScript logic changed
+- no tests required updating to accommodate behavior changes
+
+The main residual risk is purely visual and limited to how the accent feels across viewport sizes and themes, but the responsive width and preserved theme gradient help keep that risk narrow.
 
 ## Files Changed
 
 - `1.4.1 GUI Entry.html`
-- `test/readiness-ux.spec.js`
 - `pr_body.md`
 
-## Notes
+## PR Title
 
-This is a low-risk UI polish branch.
-
-The change is intentionally narrow, but it is still worth visually checking the toolbar across:
-- multiple themes
-- browser zoom levels
-- fallback fonts / minimum font-size settings
-
-That said, the implementation is specifically designed to behave better under those conditions than the earlier fixed-width approach.
+Refine header accent integration


### PR DESCRIPTION
## Summary

This branch refines the visual treatment of the sticky header card that contains the `WEG Billing Calculator` title.

The issue reported during review was a thick line appearing above the top menu/title card, making the header feel visually detached from the rest of the card surface. The previous implementation used a full-width `header::before` accent strip, which read more like a separate slab sitting on top of the card than an integrated detail.

This update replaces that full-width strip with a shorter, integrated accent tab so the header keeps its industrial styling without looking improperly assembled.

## Problem

Before this change:

- the header rendered a bright, full-width accent line across the top edge
- that line visually competed with the existing border and inset highlight already used by the card
- the combination made the `WEG Billing Calculator` panel look like it had an extra layer placed on top of it
- after the first pass at softening the line, the result became too understated and lost the intentional visual character of the header

The final goal for this branch was not simply to remove the line, but to make the top accent feel deliberate, integrated, and visually "cool" again.

## Final Approach

The header accent is still implemented through `header::before`, but its geometry and presentation were reworked:

- the accent no longer spans the full width of the header
- it now starts inset from the left edge
- it uses a compact width that scales responsively instead of stretching across the whole card
- its height was increased from a hairline into a small top tab
- a rounded lower edge was added so the shape feels attached to the header card
- a subtle shadow and inner highlight were added so the accent feels like a built-in piece of the panel rather than a painted rule

The original theme-driven gradient was preserved, so the accent still participates in the industrial palette and remains consistent with the existing brand/header styling.

## What Changed

In `1.4.1 GUI Entry.html`:

- updated the `header::before` pseudo-element used for the top accent treatment
- changed the accent from:
  - full-width
  - 3px tall
  - flat line styling
- to a new treatment that is:
  - left-inset
  - responsive in width
  - 8px tall
  - rounded at the bottom corners
  - lightly shadowed and highlighted
  - explicitly non-interactive with `pointer-events:none`

## What Did Not Change

This branch does not change:

- header layout structure
- toolbar controls
- menu behavior
- theme selection logic
- brand/title copy
- any business logic, calculations, or export workflows
- any test behavior outside of re-running the existing suite for regression confidence

This is a presentation-only polish change scoped to the header accent detail.

## User-Facing Impact

### Before

- the title/header card looked like it had a separate thick strip pasted on top
- the top edge drew too much attention away from the actual title and controls
- a first softening pass removed the harshness, but also removed too much personality

### After

- the `WEG Billing Calculator` card reads as a single integrated panel
- the header keeps a distinct styled accent without the detached-strip look
- the top detail feels more intentional and decorative instead of accidental
- the visual hierarchy shifts back toward the title and toolbar content

## Implementation Notes

The update intentionally keeps the existing gradient colors:

- copper-toned primary accent
- steel-toned trailing fade

That means the change improves the shape language of the header without forcing a broader retune of the active theme system.

The resulting accent behaves more like a design tab or integrated plate than a border override, which better matches the industrial control-panel style already present in the page chrome.

## Validation

Validated locally with:

```bash
npm test
```

Result:

- full test suite passed (`14/14`)

## Risk Assessment

Risk is low because:

- only CSS for the header accent pseudo-element changed
- no DOM structure changed
- no JavaScript logic changed
- no tests required updating to accommodate behavior changes

The main residual risk is purely visual and limited to how the accent feels across viewport sizes and themes, but the responsive width and preserved theme gradient help keep that risk narrow.

## Files Changed

- `1.4.1 GUI Entry.html`
- `pr_body.md`

## PR Title

Refine header accent integration
