### PR TITLE
Improve final check animation states

### DIFF
--- a/1.4.1 GUI Entry.html
+++ b/1.4.1 GUI Entry.html
@@ -23,6 +23,11 @@
       --radius: 18px;
       --warn-outline: rgba(255,120,120,.6);
     }
+    @property --final-usage{
+      syntax:"<percentage>";
+      inherits:false;
+      initial-value:0%;
+    }
     /* Force a light palette for export */
     :root { color-scheme: light only; }
     *{box-sizing:border-box}
@@ -2141,22 +2146,91 @@
       }
 
       @keyframes checkDangerPulse{
-        0%, 100%{ box-shadow:0 0 0 0 rgba(222,110,99,.0), 0 16px 30px rgba(7,9,12,.38); }
-        50%{ box-shadow:0 0 0 8px rgba(222,110,99,.18), 0 20px 42px rgba(7,9,12,.55); }
+        0%, 100%{
+          box-shadow:0 0 0 0 rgba(222,110,99,0), 0 18px 34px rgba(7,9,12,.38);
+          transform:translateY(0);
+        }
+        50%{
+          box-shadow:0 0 0 10px rgba(222,110,99,.15), 0 24px 44px rgba(7,9,12,.56);
+          transform:translateY(-1px);
+        }
       }
       @keyframes checkWarnSweep{
-        0%{ transform:translateX(-115%); opacity:0; }
-        24%{ opacity:.6; }
-        55%{ transform:translateX(0%); opacity:.8; }
-        100%{ transform:translateX(115%); opacity:0; }
+        0%{ transform:translateX(-125%) skewX(-16deg); opacity:0; }
+        18%{ opacity:0; }
+        44%{ opacity:.52; }
+        62%{ opacity:.78; }
+        100%{ transform:translateX(220%) skewX(-16deg); opacity:0; }
       }
       @keyframes statusOrbit{
         from{ transform:rotate(0deg); }
         to{ transform:rotate(360deg); }
       }
       @keyframes toleranceAlert{
-        0%, 100%{ filter:saturate(100%); }
-        50%{ filter:saturate(145%); }
+        0%, 100%{ filter:saturate(100%) brightness(1); }
+        50%{ filter:saturate(145%) brightness(1.08); }
+      }
+      @keyframes finalPanelDrift{
+        0%, 100%{
+          background-position:0 0, 0 50%;
+          transform:translateY(0);
+        }
+        50%{
+          background-position:0 0, 100% 50%;
+          transform:translateY(-2px);
+        }
+      }
+      @keyframes finalStatusBreathe{
+        0%, 100%{
+          transform:scale(.985);
+          box-shadow:inset 0 0 0 1px rgba(244,248,252,.05), 0 14px 24px rgba(7,9,12,.32);
+        }
+        50%{
+          transform:scale(1.02);
+          box-shadow:inset 0 0 0 1px rgba(244,248,252,.08), 0 20px 32px var(--state-glow);
+        }
+      }
+      @keyframes finalUpdateSweep{
+        0%{ transform:translateX(-140%) skewX(-18deg); opacity:0; }
+        18%{ opacity:0; }
+        42%{ opacity:.4; }
+        70%{ opacity:.22; }
+        100%{ transform:translateX(240%) skewX(-18deg); opacity:0; }
+      }
+      @keyframes finalStatusLock{
+        0%{ transform:scale(.94); filter:saturate(.82) blur(.2px); }
+        55%{ transform:scale(1.04); filter:saturate(1.08); }
+        100%{ transform:scale(1); filter:none; }
+      }
+      @keyframes finalMetricReveal{
+        from{
+          opacity:0;
+          transform:translateY(10px) scale(.985);
+        }
+        to{
+          opacity:1;
+          transform:translateY(0) scale(1);
+        }
+      }
+      @keyframes finalMetricSheen{
+        0%{ transform:translateX(-140%) skewX(-16deg); opacity:0; }
+        35%{ opacity:.34; }
+        100%{ transform:translateX(180%) skewX(-16deg); opacity:0; }
+      }
+      @keyframes toleranceShimmer{
+        0%{ transform:translateX(-140%) skewX(-16deg); opacity:0; }
+        32%{ opacity:.38; }
+        100%{ transform:translateX(220%) skewX(-16deg); opacity:0; }
+      }
+      @keyframes toleranceValuePop{
+        0%{
+          opacity:0;
+          transform:translateY(6px);
+        }
+        100%{
+          opacity:1;
+          transform:translateY(0);
+        }
       }
 
       #finalCheckBadge{
@@ -2171,16 +2245,21 @@
         background:
           linear-gradient(165deg, rgba(38,49,60,.92), rgba(25,34,43,.92)),
           linear-gradient(90deg, rgba(161,179,198,.12), transparent 42%, rgba(161,179,198,.08));
+        background-size:100% 100%, 185% 100%;
+        background-position:0 0, 0 50%;
         box-shadow:0 18px 34px rgba(8,10,13,.34);
+        transition:border-color .35s ease, box-shadow .45s ease, transform .45s ease, --final-usage .85s cubic-bezier(.22,.84,.25,1);
+        will-change:transform;
       }
       #finalCheckBadge::before{
         content:"";
         position:absolute;
-        inset:0 auto 0 -20%;
-        width:22%;
+        inset:-18% auto -18% -28%;
+        width:42%;
         background:linear-gradient(90deg, transparent, var(--state-soft), transparent);
         pointer-events:none;
         opacity:0;
+        filter:blur(6px);
       }
       #finalCheckBadge::after{
         content:"";
@@ -2189,39 +2268,47 @@
         pointer-events:none;
         background:
           linear-gradient(0deg, transparent 92%, rgba(233,239,246,.08) 92% 93%, transparent 93%),
-          linear-gradient(90deg, transparent 94%, rgba(233,239,246,.07) 94% 95%, transparent 95%);
-        opacity:.35;
+          linear-gradient(90deg, transparent 94%, rgba(233,239,246,.07) 94% 95%, transparent 95%),
+          radial-gradient(circle at 14% 50%, var(--state-glow), transparent 32%);
+        opacity:.42;
+        transition:opacity .35s ease;
       }
       #finalCheckBadge .status-wrap{
         width:124px;
         min-width:124px;
-        border-radius:24px;
+        border-radius:28px;
         border:1px solid var(--state-soft);
         background:linear-gradient(180deg, rgba(56,63,71,.84), rgba(40,47,55,.9));
         box-shadow:inset 0 0 0 1px rgba(244,248,252,.05), 0 14px 24px rgba(7,9,12,.32);
         isolation:isolate;
         overflow:visible;
+        padding:20px 14px;
+        transition:transform .75s cubic-bezier(.22,.84,.24,1), box-shadow .45s ease, border-color .35s ease, background .35s ease;
+        transform-origin:center;
       }
       #finalCheckBadge .status-wrap::after{
         content:"";
         position:absolute;
-        inset:-9px;
-        border-radius:28px;
+        inset:-10px;
+        border-radius:32px;
         pointer-events:none;
         background:
-          conic-gradient(from -90deg, var(--state-main) var(--usage), rgba(133,149,168,.2) var(--usage));
+          conic-gradient(from -90deg, var(--state-main) 0 var(--usage), rgba(133,149,168,.2) var(--usage) 100%);
         -webkit-mask:radial-gradient(circle, transparent 63%, #000 66%);
         mask:radial-gradient(circle, transparent 63%, #000 66%);
-        opacity:.95;
+        opacity:.92;
+        filter:drop-shadow(0 0 14px var(--state-glow));
+        transition:opacity .35s ease, filter .45s ease;
       }
       #finalCheckBadge .status-wrap::before{
         content:"";
         position:absolute;
-        inset:-16px;
-        border-radius:34px;
+        inset:-18px;
+        border-radius:36px;
         border:1px dashed rgba(233,239,246,.22);
-        opacity:.35;
+        opacity:.28;
         animation:statusOrbit 11s linear infinite;
+        transition:opacity .35s ease, border-color .35s ease;
       }
       #finalCheckBadge .status{
         color:var(--state-text);
@@ -2233,10 +2320,24 @@
         gap:12px 14px;
       }
       #finalCheckBadge .metric{
+        position:relative;
+        overflow:hidden;
+        isolation:isolate;
         border:1px solid rgba(160,178,197,.16);
         border-radius:11px;
         padding:10px 12px;
         background:linear-gradient(180deg, rgba(45,56,67,.7), rgba(31,40,50,.78));
+        min-height:90px;
+        transition:transform .35s ease, border-color .35s ease, box-shadow .35s ease, background .35s ease;
+      }
+      #finalCheckBadge .metric::before{
+        content:"";
+        position:absolute;
+        inset:-22% auto -22% -42%;
+        width:36%;
+        background:linear-gradient(90deg, transparent, rgba(255,255,255,.26), transparent);
+        opacity:0;
+        pointer-events:none;
       }
       #finalCheckBadge .metric:nth-child(3){
         border-color:var(--state-soft);
@@ -2247,6 +2348,8 @@
       }
       #finalCheckBadge .metric-value{
         color:#eef4fb;
+        font-variant-numeric:tabular-nums;
+        transition:color .35s ease, transform .35s ease;
       }
       #finalCheckBadge .metric-value.good{
         color:var(--good);
@@ -2262,9 +2365,11 @@
         --state-main: rgba(68,194,138,.94);
         --state-soft: rgba(68,194,138,.34);
         --state-glow: rgba(68,194,138,.28);
+        animation:finalPanelDrift 10s ease-in-out infinite;
       }
       #finalCheckBadge[data-state="ok"] .status-wrap{
         background:linear-gradient(180deg, rgba(56,84,72,.86), rgba(38,64,53,.9));
+        animation:finalStatusBreathe 4.8s ease-in-out infinite;
       }
 
       #finalCheckBadge[data-state="warn"]{
@@ -2274,27 +2379,59 @@
       }
       #finalCheckBadge[data-state="warn"] .status-wrap{
         background:linear-gradient(180deg, rgba(86,74,56,.86), rgba(63,53,39,.9));
+        animation:finalStatusBreathe 3.9s ease-in-out infinite;
       }
       #finalCheckBadge[data-state="warn"]::before{
-        animation:checkWarnSweep 3.1s ease-in-out infinite;
+        opacity:.7;
+        animation:checkWarnSweep 3.4s cubic-bezier(.22,.78,.24,1) infinite;
       }
 
       #finalCheckBadge[data-state="danger"]{
         --state-main: rgba(222,110,99,.98);
         --state-soft: rgba(222,110,99,.36);
         --state-glow: rgba(222,110,99,.34);
-        animation:checkDangerPulse 1.9s ease-in-out infinite;
+        animation:checkDangerPulse 2.35s cubic-bezier(.32,0,.2,1) infinite;
       }
       #finalCheckBadge[data-state="danger"] .status-wrap{
         background:linear-gradient(180deg, rgba(95,61,59,.86), rgba(70,44,43,.9));
+        animation:finalStatusBreathe 2.5s ease-in-out infinite;
       }
       #finalCheckBadge[data-state="danger"]::before{
-        animation:checkWarnSweep 2.2s linear infinite;
+        opacity:.82;
+        animation:checkWarnSweep 1.9s linear infinite;
       }
 
       #finalCheckBadge[data-state="none"]{
         --state-main: rgba(158,176,196,.72);
         --state-soft: rgba(158,176,196,.18);
+        animation:none;
+      }
+      #finalCheckBadge[data-state="none"] .status-wrap{
+        animation:none;
+      }
+      #finalCheckBadge[data-state="none"]::before{
+        animation:none;
+        opacity:0;
+      }
+
+      #finalCheckBadge.is-refreshing::before{
+        opacity:.78;
+        animation:finalUpdateSweep 1.1s cubic-bezier(.22,.82,.23,1) 1;
+      }
+      #finalCheckBadge.is-refreshing .status-wrap{
+        animation:finalStatusLock .82s cubic-bezier(.16,.84,.24,1) 1;
+      }
+      #finalCheckBadge.is-refreshing .metric{
+        animation:finalMetricReveal .68s cubic-bezier(.18,.82,.24,1) both;
+      }
+      #finalCheckBadge.is-refreshing .metric:nth-child(2){
+        animation-delay:.06s;
+      }
+      #finalCheckBadge.is-refreshing .metric:nth-child(3){
+        animation-delay:.12s;
+      }
+      #finalCheckBadge.is-refreshing .metric::before{
+        animation:finalMetricSheen .9s ease-out 1;
       }
 
       .tolerance-card{
@@ -2302,6 +2439,7 @@
         --tol-soft: rgba(164,181,200,.3);
         border-color:rgba(160,178,197,.22);
         background:linear-gradient(160deg, rgba(39,49,60,.82), rgba(26,34,43,.86));
+        transition:box-shadow .35s ease, border-color .35s ease, transform .45s ease;
       }
       .tolerance-title{
         color:rgba(224,232,241,.84);
@@ -2325,11 +2463,24 @@
           linear-gradient(90deg, transparent 99.2%, rgba(255,170,162,.65) 99.2% 100%, transparent 100%);
       }
       .tolerance-bar-fill{
+        position:relative;
         background:linear-gradient(90deg, var(--tol-main), color-mix(in oklab, var(--tol-main), white 12%));
         box-shadow:0 0 14px var(--tol-soft);
+        overflow:hidden;
+        transition:width .78s cubic-bezier(.22,.84,.25,1), background .35s ease, box-shadow .35s ease, filter .35s ease;
+      }
+      .tolerance-bar-fill::after{
+        content:"";
+        position:absolute;
+        inset:-20% auto -20% -34%;
+        width:34%;
+        background:linear-gradient(90deg, transparent, rgba(255,255,255,.36), transparent);
+        opacity:0;
+        pointer-events:none;
       }
       .tolerance-value{
         font-variant-numeric:tabular-nums;
+        transition:color .35s ease, transform .35s ease;
       }
       .tolerance-card[data-state="ok"]{
         --tol-main: rgba(68,194,138,.95);
@@ -2342,7 +2493,7 @@
       .tolerance-card[data-state="danger"]{
         --tol-main: rgba(222,110,99,.95);
         --tol-soft: rgba(222,110,99,.36);
-        animation:toleranceAlert 1.6s ease-in-out infinite;
+        animation:toleranceAlert 1.85s ease-in-out infinite;
       }
       .tolerance-card[data-state="danger"] .tolerance-bar-track{
         background:
@@ -2350,6 +2501,12 @@
       }
       .tolerance-card[data-state="danger"] .tolerance-value{
         color:#ffb3a9;
+      }
+      .tolerance-card.is-refreshing .tolerance-bar-fill::after{
+        animation:toleranceShimmer .95s ease-out 1;
+      }
+      .tolerance-card.is-refreshing .tolerance-value{
+        animation:toleranceValuePop .58s cubic-bezier(.18,.82,.24,1) both;
       }
 
       #moreMenu .menu-panel [data-theme-option][data-active="true"]{
@@ -3517,6 +3674,14 @@
       @media (prefers-reduced-motion: reduce){
         #finalCheckBadge,
         #finalCheckBadge::before,
+        #finalCheckBadge[data-state="ok"],
+        #finalCheckBadge[data-state="ok"] .status-wrap,
+        #finalCheckBadge[data-state="warn"] .status-wrap,
+        #finalCheckBadge[data-state="danger"] .status-wrap,
+        #finalCheckBadge.is-refreshing::before,
+        #finalCheckBadge.is-refreshing .status-wrap,
+        #finalCheckBadge.is-refreshing .metric,
+        #finalCheckBadge.is-refreshing .metric::before,
         #finalCheckBadge .status-wrap::before,
         html[data-theme="arctic"] body::before,
         html[data-theme="military"] body::before,
@@ -3527,7 +3692,9 @@
         body.boot-sequence,
         body.boot-sequence .brand h1,
         body.boot-sequence .toolbar,
-        .tolerance-card[data-state="danger"]{
+        .tolerance-card[data-state="danger"],
+        .tolerance-card.is-refreshing .tolerance-bar-fill::after,
+        .tolerance-card.is-refreshing .tolerance-value{
           animation:none !important;
         }
         body.boot-sequence #bootFx{
@@ -5678,6 +5845,21 @@
     const roundUp0 = x => Math.ceil(x);
     const round2 = x => Math.round(x * 100) / 100;
     const hasAtMostTwoDecimals = v => Math.abs(Math.round(v * 100) - v * 100) < 1e-6;
+    const transientClassTimers = new WeakMap();
+    function restartTransientClass(el, className, duration=1200){
+      if(!el) return;
+      const timers = transientClassTimers.get(el) || {};
+      if(timers[className]) clearTimeout(timers[className]);
+      el.classList.remove(className);
+      void el.offsetWidth;
+      el.classList.add(className);
+      timers[className] = setTimeout(()=>{
+        el.classList.remove(className);
+        const nextTimers = transientClassTimers.get(el);
+        if(nextTimers) delete nextTimers[className];
+      }, duration);
+      transientClassTimers.set(el, timers);
+    }
 
     // Final reconciliation tolerance (INR); hoisted for clarity & micro-perf.
     // Stability guard: updated per business requirement from &#8377;0.05 &rarr; &#8377;50.00.
@@ -6749,6 +6931,19 @@
           else if (usageFinite && rawUsage >= 70) state = 'warn';
           else state = 'ok';
         }
+        const tolState = !hasFinalData ? 'none' : (rawUsage > 100 ? 'danger' : (rawUsage >= 70 ? 'warn' : 'ok'));
+        const motionSignature = [
+          state,
+          tolState,
+          round2(I9_check),
+          round2(FINAL),
+          round2(deltaFinal),
+          usageFinite ? Math.round(rawUsage * 10) / 10 : 'na'
+        ].join('|');
+        const previousMotionSignature = badge.dataset.motionSignature || '';
+        const shouldAnimateRefresh = !!previousMotionSignature && previousMotionSignature !== motionSignature;
+        badge.dataset.motionSignature = motionSignature;
+        if (tolCardEl) tolCardEl.dataset.motionSignature = motionSignature;
 
         if (i9Span) i9Span.textContent = toInr(I9_check);
         if (finalSpan) finalSpan.textContent = toInr(FINAL);
@@ -6788,7 +6983,6 @@
           tolValueEl.textContent = displayText;
         }
         if (tolCardEl) {
-          const tolState = !hasFinalData ? 'none' : (rawUsage > 100 ? 'danger' : (rawUsage >= 70 ? 'warn' : 'ok'));
           tolCardEl.classList.toggle('over', tolState === 'danger');
           tolCardEl.dataset.state = tolState;
           tolCardEl.dataset.glow = tolState === 'danger' ? 'danger' : (tolState === 'warn' ? 'warn' : 'none');
@@ -6799,6 +6993,10 @@
             : `Tolerance usage ${tolText}, state ${tolState}.`;
           tolCardEl.setAttribute('aria-label', tolA11y);
           tolCardEl.title = tolA11y;
+        }
+        if (shouldAnimateRefresh) {
+          restartTransientClass(badge, 'is-refreshing', 1150);
+          restartTransientClass(tolCardEl, 'is-refreshing', 950);
         }
       }
       refreshExtrasOutputs();

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,95 +1,140 @@
 ## Summary
 
-This branch refines the visual treatment of the sticky header card that contains the `WEG Billing Calculator` title.
+This branch improves the animation and motion behavior of the `Final Bill Check` card and its `Tolerance Usage` panel in `1.4.1 GUI Entry.html`.
 
-The issue reported during review was a thick line appearing above the top menu/title card, making the header feel visually detached from the rest of the card surface. The previous implementation used a full-width `header::before` accent strip, which read more like a separate slab sitting on top of the card than an integrated detail.
+The previous version already had state-based color changes, but the motion treatment still felt generic:
 
-This update replaces that full-width strip with a shorter, integrated accent tab so the header keeps its industrial styling without looking improperly assembled.
+- repeated sweep effects ran continuously regardless of whether values changed
+- the status area pulsed in a fairly blunt way, especially in warning and danger states
+- the tolerance bar updated abruptly with limited visual connection to the circular status ring
+- there was no short "settle" animation when the underlying reconciliation values actually changed
+
+The goal here was to make the component feel more intentional and informative rather than merely more animated.
 
 ## Problem
 
-Before this change:
+Before this change, the final-check animation had a few UX issues:
 
-- the header rendered a bright, full-width accent line across the top edge
-- that line visually competed with the existing border and inset highlight already used by the card
-- the combination made the `WEG Billing Calculator` panel look like it had an extra layer placed on top of it
-- after the first pass at softening the line, the result became too understated and lost the intentional visual character of the header
+- motion did not clearly distinguish between passive state and fresh updates
+- the strongest effects were always-on instead of being reserved for meaningful changes
+- the status ring and tolerance fill did not feel synchronized
+- the card could read as visually noisy while still not giving a strong sense of "new values just landed"
+- reduced-motion handling existed, but the new animation design also needed to respect it fully
 
-The final goal for this branch was not simply to remove the line, but to make the top accent feel deliberate, integrated, and visually "cool" again.
+The requested improvement was specifically about making this animation better, not about changing reconciliation logic or altering any financial calculations.
 
-## Final Approach
+## Approach
 
-The header accent is still implemented through `header::before`, but its geometry and presentation were reworked:
+The update keeps the existing DOM structure and calculation rules, but changes how motion is produced and when it is triggered.
 
-- the accent no longer spans the full width of the header
-- it now starts inset from the left edge
-- it uses a compact width that scales responsively instead of stretching across the whole card
-- its height was increased from a hairline into a small top tab
-- a rounded lower edge was added so the shape feels attached to the header card
-- a subtle shadow and inner highlight were added so the accent feels like a built-in piece of the panel rather than a painted rule
+The new animation model separates motion into two categories:
 
-The original theme-driven gradient was preserved, so the accent still participates in the industrial palette and remains consistent with the existing brand/header styling.
+1. Passive state motion
 
-## What Changed
+- `ok` uses a slow panel drift and a restrained breathing effect
+- `warn` uses a more noticeable scan sweep and a slightly tighter breathing cycle
+- `danger` keeps the most urgent motion, but with a cleaner pulse cadence and less "cheap" flicker
+- `none` remains quiet
 
-In `1.4.1 GUI Entry.html`:
+2. Update-triggered motion
 
-- updated the `header::before` pseudo-element used for the top accent treatment
-- changed the accent from:
-  - full-width
-  - 3px tall
-  - flat line styling
-- to a new treatment that is:
-  - left-inset
-  - responsive in width
-  - 8px tall
-  - rounded at the bottom corners
-  - lightly shadowed and highlighted
-  - explicitly non-interactive with `pointer-events:none`
+- when the final-check values actually change, the card now runs a one-shot refresh sequence
+- the status block performs a short lock-in animation
+- the metric tiles reveal with light staggering
+- the tolerance bar gets a one-pass shimmer
+- this refresh animation does not replay endlessly; it only runs when the relevant values/state change
+
+This produces motion that communicates both current status and recent updates.
+
+## Implementation Details
+
+### CSS changes
+
+The final-check visuals in `1.4.1 GUI Entry.html` were reworked with a more structured motion system:
+
+- registered `--final-usage` with `@property` so the circular usage ring can animate smoothly as a percentage value
+- refined existing keyframes for warning and danger motion so they feel less harsh and less arbitrary
+- added new keyframes for:
+  - panel drift
+  - status breathing
+  - one-shot refresh sweep
+  - status lock-in
+  - metric reveal
+  - metric sheen
+  - tolerance shimmer
+  - tolerance value pop
+- upgraded the `#finalCheckBadge` styling so background motion, state glow, and the conic ring read as one visual system
+- gave metric tiles their own overflow-isolated surface so one-shot sheen/reveal effects can happen cleanly
+- added smoother transitions to the tolerance bar and tolerance value
+- expanded `prefers-reduced-motion` coverage to include the new state-driven and refresh-only animations
+
+### JavaScript changes
+
+The reconciliation logic still computes the same values:
+
+- `I9_check`
+- `deltaFinal`
+- status state (`ok`, `warn`, `danger`, `none`)
+- tolerance state
+
+What changed is how the UI responds after computing them:
+
+- introduced a small helper that safely restarts transient animation classes
+- added a `motionSignature` built from:
+  - final-check state
+  - tolerance state
+  - rounded `I9_check`
+  - rounded `FINAL`
+  - rounded delta
+  - tolerance usage
+- the signature is stored on the badge and compared on each recompute
+- if the signature changes, the card applies short-lived `is-refreshing` classes to the badge and tolerance card
+- if the signature does not change, the one-shot refresh animation does not replay
+
+This keeps the animation responsive without making the panel feel restless during unrelated recomputations.
 
 ## What Did Not Change
 
 This branch does not change:
 
-- header layout structure
-- toolbar controls
-- menu behavior
-- theme selection logic
-- brand/title copy
-- any business logic, calculations, or export workflows
-- any test behavior outside of re-running the existing suite for regression confidence
+- the formula used for final reconciliation
+- the final-check tolerance amount
+- any values shown in the three metrics
+- accessibility narration text content structure, beyond reflecting the same computed states as before
+- general page layout outside the final-check and tolerance panels
+- export, persistence, or other billing workflows
 
-This is a presentation-only polish change scoped to the header accent detail.
+The change is intentionally scoped to presentation and animation behavior around the existing reconciliation output.
 
-## User-Facing Impact
+## User-Facing Result
 
-### Before
+After this change:
 
-- the title/header card looked like it had a separate thick strip pasted on top
-- the top edge drew too much attention away from the actual title and controls
-- a first softening pass removed the harshness, but also removed too much personality
+- the circular status ring eases into new usage values instead of feeling static or abrupt
+- `Stable`, `Watch`, and `Action` have clearer visual personalities
+- strong motion is reserved for actual value updates rather than always running at full intensity
+- the tolerance bar now feels tied to the same status system as the main badge
+- the component is more polished on repeated recalculations because it "locks in" rather than just pulsing forever
 
-### After
+## Accessibility and Motion Safety
 
-- the `WEG Billing Calculator` card reads as a single integrated panel
-- the header keeps a distinct styled accent without the detached-strip look
-- the top detail feels more intentional and decorative instead of accidental
-- the visual hierarchy shifts back toward the title and toolbar content
+The new motion system preserves the existing reduced-motion intent and extends it so the new one-shot refresh effects are also suppressed when `prefers-reduced-motion: reduce` is active.
 
-## Implementation Notes
-
-The update intentionally keeps the existing gradient colors:
-
-- copper-toned primary accent
-- steel-toned trailing fade
-
-That means the change improves the shape language of the header without forcing a broader retune of the active theme system.
-
-The resulting accent behaves more like a design tab or integrated plate than a border override, which better matches the industrial control-panel style already present in the page chrome.
+That matters here because the change adds more nuanced motion, and the accessibility behavior needed to scale with it rather than regress.
 
 ## Validation
 
-Validated locally with:
+Static validation completed:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- passed with no whitespace or patch-format issues
+
+Attempted test command:
 
 ```bash
 npm test
@@ -97,24 +142,36 @@ npm test
 
 Result:
 
-- full test suite passed (`14/14`)
+- could not run in the current environment
+- local Node/NPM is failing under WSL1 with:
+  - `WSL 1 is not supported. Please upgrade to WSL 2 or above.`
+  - `Could not determine Node.js install directory`
+
+Because of that environment limitation, this branch does not include a successful automated test run.
 
 ## Risk Assessment
 
-Risk is low because:
+Risk is moderate-low and mostly visual:
 
-- only CSS for the header accent pseudo-element changed
-- no DOM structure changed
-- no JavaScript logic changed
-- no tests required updating to accommodate behavior changes
+- the business logic and reconciliation formulas are unchanged
+- the DOM structure is unchanged
+- the biggest changes are to CSS motion and small UI-state bookkeeping for transient animation classes
 
-The main residual risk is purely visual and limited to how the accent feels across viewport sizes and themes, but the responsive width and preserved theme gradient help keep that risk narrow.
+Residual risks:
+
+- some animation timing may still need subjective tuning after browser review
+- `@property` support is modern-browser oriented, though the UI still has reasonable fallback behavior if it is not fully honored
+- visual balance may vary slightly by theme because the badge inherits each theme's palette treatment
 
 ## Files Changed
 
 - `1.4.1 GUI Entry.html`
 - `pr_body.md`
 
-## PR Title
+## Suggested Commit Message
 
-Refine header accent integration
+`Improve final check animation states`
+
+## Suggested PR Title
+
+`Improve final check animation states`


### PR DESCRIPTION
## Summary

This branch improves the animation and motion behavior of the `Final Bill Check` card and its `Tolerance Usage` panel in `1.4.1 GUI Entry.html`.

The previous version already had state-based color changes, but the motion treatment still felt generic:

- repeated sweep effects ran continuously regardless of whether values changed
- the status area pulsed in a fairly blunt way, especially in warning and danger states
- the tolerance bar updated abruptly with limited visual connection to the circular status ring
- there was no short "settle" animation when the underlying reconciliation values actually changed

The goal here was to make the component feel more intentional and informative rather than merely more animated.

## Problem

Before this change, the final-check animation had a few UX issues:

- motion did not clearly distinguish between passive state and fresh updates
- the strongest effects were always-on instead of being reserved for meaningful changes
- the status ring and tolerance fill did not feel synchronized
- the card could read as visually noisy while still not giving a strong sense of "new values just landed"
- reduced-motion handling existed, but the new animation design also needed to respect it fully

The requested improvement was specifically about making this animation better, not about changing reconciliation logic or altering any financial calculations.

## Approach

The update keeps the existing DOM structure and calculation rules, but changes how motion is produced and when it is triggered.

The new animation model separates motion into two categories:

1. Passive state motion

- `ok` uses a slow panel drift and a restrained breathing effect
- `warn` uses a more noticeable scan sweep and a slightly tighter breathing cycle
- `danger` keeps the most urgent motion, but with a cleaner pulse cadence and less "cheap" flicker
- `none` remains quiet

2. Update-triggered motion

- when the final-check values actually change, the card now runs a one-shot refresh sequence
- the status block performs a short lock-in animation
- the metric tiles reveal with light staggering
- the tolerance bar gets a one-pass shimmer
- this refresh animation does not replay endlessly; it only runs when the relevant values/state change

This produces motion that communicates both current status and recent updates.

## Implementation Details

### CSS changes

The final-check visuals in `1.4.1 GUI Entry.html` were reworked with a more structured motion system:

- registered `--final-usage` with `@property` so the circular usage ring can animate smoothly as a percentage value
- refined existing keyframes for warning and danger motion so they feel less harsh and less arbitrary
- added new keyframes for:
  - panel drift
  - status breathing
  - one-shot refresh sweep
  - status lock-in
  - metric reveal
  - metric sheen
  - tolerance shimmer
  - tolerance value pop
- upgraded the `#finalCheckBadge` styling so background motion, state glow, and the conic ring read as one visual system
- gave metric tiles their own overflow-isolated surface so one-shot sheen/reveal effects can happen cleanly
- added smoother transitions to the tolerance bar and tolerance value
- expanded `prefers-reduced-motion` coverage to include the new state-driven and refresh-only animations

### JavaScript changes

The reconciliation logic still computes the same values:

- `I9_check`
- `deltaFinal`
- status state (`ok`, `warn`, `danger`, `none`)
- tolerance state

What changed is how the UI responds after computing them:

- introduced a small helper that safely restarts transient animation classes
- added a `motionSignature` built from:
  - final-check state
  - tolerance state
  - rounded `I9_check`
  - rounded `FINAL`
  - rounded delta
  - tolerance usage
- the signature is stored on the badge and compared on each recompute
- if the signature changes, the card applies short-lived `is-refreshing` classes to the badge and tolerance card
- if the signature does not change, the one-shot refresh animation does not replay

This keeps the animation responsive without making the panel feel restless during unrelated recomputations.

## What Did Not Change

This branch does not change:

- the formula used for final reconciliation
- the final-check tolerance amount
- any values shown in the three metrics
- accessibility narration text content structure, beyond reflecting the same computed states as before
- general page layout outside the final-check and tolerance panels
- export, persistence, or other billing workflows

The change is intentionally scoped to presentation and animation behavior around the existing reconciliation output.

## User-Facing Result

After this change:

- the circular status ring eases into new usage values instead of feeling static or abrupt
- `Stable`, `Watch`, and `Action` have clearer visual personalities
- strong motion is reserved for actual value updates rather than always running at full intensity
- the tolerance bar now feels tied to the same status system as the main badge
- the component is more polished on repeated recalculations because it "locks in" rather than just pulsing forever

## Accessibility and Motion Safety

The new motion system preserves the existing reduced-motion intent and extends it so the new one-shot refresh effects are also suppressed when `prefers-reduced-motion: reduce` is active.

That matters here because the change adds more nuanced motion, and the accessibility behavior needed to scale with it rather than regress.

## Validation

Static validation completed:

```bash
git diff --check
```

Result:

- passed with no whitespace or patch-format issues

Attempted test command:

```bash
npm test
```

Result:

- could not run in the current environment
- local Node/NPM is failing under WSL1 with:
  - `WSL 1 is not supported. Please upgrade to WSL 2 or above.`
  - `Could not determine Node.js install directory`

Because of that environment limitation, this branch does not include a successful automated test run.

## Risk Assessment

Risk is moderate-low and mostly visual:

- the business logic and reconciliation formulas are unchanged
- the DOM structure is unchanged
- the biggest changes are to CSS motion and small UI-state bookkeeping for transient animation classes

Residual risks:

- some animation timing may still need subjective tuning after browser review
- `@property` support is modern-browser oriented, though the UI still has reasonable fallback behavior if it is not fully honored
- visual balance may vary slightly by theme because the badge inherits each theme's palette treatment

## Files Changed

- `1.4.1 GUI Entry.html`
- `pr_body.md`

## Suggested Commit Message

`Improve final check animation states`

## Suggested PR Title

`Improve final check animation states`
